### PR TITLE
Removed double forward slash in the requestPath of HttpHealthProbe

### DIFF
--- a/main/health.go
+++ b/main/health.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -77,36 +79,29 @@ func (p *TcpHealthProbe) address() string {
 func NewHttpHealthProbe(protocol string, requestPath string, port int) *HttpHealthProbe {
 	p := new(HttpHealthProbe)
 
-	timeout := time.Duration(30 * time.Second)
-
-	var transport *http.Transport
-	if protocol == "https" {
-		transport = &http.Transport{
+	p.HttpClient = &http.Client{
+		CheckRedirect: noRedirect,
+		Timeout:       time.Duration(30 * time.Second),
+		Transport: &http.Transport{
 			// Ignore authentication/certificate failures - just validate that the localhost
-			// endpoint responds with HTTP.OK
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		}
-
-		p.HttpClient = &http.Client{
-			CheckRedirect: noRedirect,
-			Timeout:       timeout,
-			Transport:     transport,
-		}
-	} else if protocol == "http" {
-		p.HttpClient = &http.Client{
-			CheckRedirect: noRedirect,
-			Timeout:       timeout,
-		}
+			// endpoint responds with http.StatusOK
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
 	}
 
-	portString := ""
-	if protocol == "http" && port != 0 && port != 80 {
-		portString = ":" + strconv.Itoa(port)
-	} else if protocol == "https" && port != 0 && port != 443 {
-		portString = ":" + strconv.Itoa(port)
+	u := url.URL{
+		Scheme: protocol,
+		Host:   "localhost",
+		Path:   requestPath,
 	}
 
-	p.Address = protocol + "://localhost" + portString + "/" + requestPath
+	if port != 0 {
+		u.Host = fmt.Sprintf("%s:%d", u.Host, port)
+	}
+
+	p.Address = u.String()
 	return p
 }
 

--- a/main/health_test.go
+++ b/main/health_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewHttpHealthProbe(t *testing.T) {
+	requestPath := "/healthcheck"
+
+	type test struct {
+		name     string
+		protocol string
+		port     int
+		expected string
+	}
+
+	tests := []test{
+		{name: "https without port", protocol: "https", expected: "https://localhost/healthcheck"},
+		{name: "https with port", protocol: "https", port: 8443, expected: "https://localhost:8443/healthcheck"},
+		{name: "http without port", protocol: "http", expected: "http://localhost/healthcheck"},
+		{name: "http with port", protocol: "http", port: 8080, expected: "http://localhost:8080/healthcheck"},
+	}
+
+	for _, tc := range tests {
+		hhp := NewHttpHealthProbe(tc.protocol, requestPath, tc.port)
+
+		assert.Equal(t, tc.expected, hhp.Address)
+	}
+}


### PR DESCRIPTION
If requestPath has a leading slash (eg, `/healthcheck`), an additional slash (`//healthcheck`) was being added which causes issues for some backends.