### PR TITLE
Crash Resiliency and Optional Slash Prefix For RequestPath

### DIFF
--- a/integration-test/test/handler-commands.bats
+++ b/integration-test/test/handler-commands.bats
@@ -149,6 +149,21 @@ teardown(){
     echo "status_file=$status_file"; [[ "$status_file" = *'Application found to be healthy'* ]]
 }
 
+@test "handler command: enable - healthy http probe prefixing requestPath with a slash" {
+    mk_container sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable"
+    push_settings '
+    {
+        "protocol": "http",
+        "port": 8080,
+        "requestPath": "/health"
+    }' ''
+    run start_container
+    echo "$output"
+
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    echo "status_file=$status_file"; [[ "$status_file" = *'Application found to be healthy'* ]]
+}
+
 @test "handler command: enable - healthy https probe" {
     mk_container sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -117,7 +117,7 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 			prevState = state
 		}
 
-		err := reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, healthStatusToStatusType[state], substatusName, healthStatusToMessage[state])
+		err = reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, healthStatusToStatusType[state], substatusName, healthStatusToMessage[state])
 		if (err != nil) {
 			ctx.Log("error", err);
 		}

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -105,7 +105,7 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 	for {
 		state, err := probe.evaluate(ctx)
 		if err != nil {
-			return "", errors.Wrap(err, "failed to evaluate health")
+			ctx.Log("error", err);
 		}
 
 		if shutdown {
@@ -117,7 +117,10 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 			prevState = state
 		}
 
-		reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, healthStatusToStatusType[state], substatusName, healthStatusToMessage[state])
+		err := reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, healthStatusToStatusType[state], substatusName, healthStatusToMessage[state])
+		if (err != nil) {
+			ctx.Log("error", err);
+		}
 		time.Sleep(5 * time.Second)
 
 		if shutdown {

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -106,8 +106,7 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 		state, err := probe.evaluate(ctx)
 		if err != nil {
 			ctx.Log("error", err)
-		}
-		else {
+		} else {
 			if shutdown {
 				return "", errTerminated
 			}

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -107,20 +107,22 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 		if err != nil {
 			ctx.Log("error", err)
 		}
-
-		if shutdown {
-			return "", errTerminated
+		else {
+			if shutdown {
+				return "", errTerminated
+			}
+	
+			if prevState != state {
+				ctx.Log("event", stateChangeLogMap[state])
+				prevState = state
+			}
+	
+			err = reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, healthStatusToStatusType[state], substatusName, healthStatusToMessage[state])
+			if (err != nil) {
+				ctx.Log("error", err)
+			}
 		}
 
-		if prevState != state {
-			ctx.Log("event", stateChangeLogMap[state])
-			prevState = state
-		}
-
-		err = reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, healthStatusToStatusType[state], substatusName, healthStatusToMessage[state])
-		if (err != nil) {
-			ctx.Log("error", err)
-		}
 		time.Sleep(5 * time.Second)
 
 		if shutdown {

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -105,7 +105,7 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 	for {
 		state, err := probe.evaluate(ctx)
 		if err != nil {
-			ctx.Log("error", err);
+			ctx.Log("error", err)
 		}
 
 		if shutdown {
@@ -119,7 +119,7 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 
 		err = reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, healthStatusToStatusType[state], substatusName, healthStatusToMessage[state])
 		if (err != nil) {
-			ctx.Log("error", err);
+			ctx.Log("error", err)
 		}
 		time.Sleep(5 * time.Second)
 

--- a/main/health.go
+++ b/main/health.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
@@ -105,7 +106,11 @@ func NewHttpHealthProbe(protocol string, requestPath string, port int) *HttpHeal
 	} else if protocol == "https" && port != 0 && port != 443 {
 		portString = ":" + strconv.Itoa(port)
 	}
-
+	_, length := utf8.DecodeRuneInString(s)
+	// remove first slash since we want requestPath to be defined without having to prefix with a slash
+	if (length > 0 && requestPath[0] == '/') {
+		requestPath = requestPath[length:]
+	}
 	p.Address = protocol + "://localhost" + portString + "/" + requestPath
 	return p
 }

--- a/main/health.go
+++ b/main/health.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-	"unicode/utf8"
+	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
@@ -106,11 +106,9 @@ func NewHttpHealthProbe(protocol string, requestPath string, port int) *HttpHeal
 	} else if protocol == "https" && port != 0 && port != 443 {
 		portString = ":" + strconv.Itoa(port)
 	}
-	_, length := utf8.DecodeRuneInString(requestPath)
 	// remove first slash since we want requestPath to be defined without having to prefix with a slash
-	if (length > 0 && requestPath[0] == '/') {
-		requestPath = requestPath[length:]
-	}
+	requestPath = strings.TrimPrefix(requestPath, "/")
+
 	p.Address = protocol + "://localhost" + portString + "/" + requestPath
 	return p
 }

--- a/main/health.go
+++ b/main/health.go
@@ -106,7 +106,7 @@ func NewHttpHealthProbe(protocol string, requestPath string, port int) *HttpHeal
 	} else if protocol == "https" && port != 0 && port != 443 {
 		portString = ":" + strconv.Itoa(port)
 	}
-	_, length := utf8.DecodeRuneInString(s)
+	_, length := utf8.DecodeRuneInString(requestPath)
 	// remove first slash since we want requestPath to be defined without having to prefix with a slash
 	if (length > 0 && requestPath[0] == '/') {
 		requestPath = requestPath[length:]


### PR DESCRIPTION
Changes:
 - in the enable for loop, I changed the error handling to just print the error message as we want this to be crash resilient. Also, we want to write unhealthy in the status file when probe.evaluate throws an error
- requestPath is changed to remove a prefix slash since we want this to be optional when defining the requestPath 