### PR TITLE
Update shim and Makefile for ARM64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 BINDIR=bin
 BIN=applicationhealth-extension
+BIN_ARM64=applicationhealth-extension-arm64
 BUNDLEDIR=bundle
 BUNDLE=applicationhealth-extension.zip
 TESTBINDIR=testbin
@@ -8,6 +9,7 @@ WEBSERVERBIN=webserver
 bundle: clean binary
 	@mkdir -p $(BUNDLEDIR)
 	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/$(BIN)
+	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/$(BIN_ARM64)
 	zip ./$(BUNDLEDIR)/$(BUNDLE) ./$(BINDIR)/applicationhealth-shim
 	zip -j ./$(BUNDLEDIR)/$(BUNDLE) ./misc/HandlerManifest.json
 	zip -j ./$(BUNDLEDIR)/$(BUNDLE) ./misc/manifest.xml
@@ -24,6 +26,9 @@ binary: clean
 	GOOS=linux GOARCH=amd64 govvv build -v \
 	  -ldflags "-X main.Version=`grep -E -m 1 -o '<Version>(.*)</Version>' misc/manifest.xml | awk -F">" '{print $$2}' | awk -F"<" '{print $$1}'`" \
 	  -o $(TESTBINDIR)/$(WEBSERVERBIN) ./integration-test/webserver
+	GOOS=linux GOARCH=arm64 govvv build -v \
+	  -ldflags "-X main.Version=`grep -E -m 1 -o '<Version>(.*)</Version>' misc/manifest.xml | awk -F">" '{print $$2}' | awk -F"<" '{print $$1}'`" \
+	  -o $(BINDIR)/$(BIN_ARM64) ./main 
 clean:
 	rm -rf "$(BINDIR)" "$(BUNDLEDIR)" "$(TESTBINDIR)"
 

--- a/misc/applicationhealth-shim
+++ b/misc/applicationhealth-shim
@@ -4,7 +4,11 @@ set -euo pipefail
 readonly SCRIPT_DIR=$(dirname "$0")
 readonly LOG_DIR="/var/log/azure/applicationhealth-extension"
 readonly LOG_FILE=handler.log
-readonly HANDLER_BIN="applicationhealth-extension"
+readonly ARCHITECTURE=$(uname -p)
+HANDLER_BIN="applicationhealth-extension"
+if [ $ARCHITECTURE == "arm64" ] || [ $ARCHITECTURE == "aarch64" ]; then
+     HANDLER_BIN="applicationhealth-extension-arm64";
+fi
 
 # status_file returns the .status file path we are supposed to write
 # by determining the highest sequence number from ./config/*.settings files.


### PR DESCRIPTION
Since ext is written in Go, binary will be generated for both arm64 and x64 and respective bin will be chosen dependent on architecture.

Referenced RunCommand ext which is also written in Go for [Makefile](https://github.com/Azure/run-command-extension-linux/pull/8/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52) and [shim](https://github.com/Azure/run-command-extension-linux/pull/8/files#diff-f73f2dc07e23db99db0ef8b5e9f3e82c4c0efd64d85020efd9e08d1bfed9bb98) changes.





