### PR TITLE
Remove additionalProperties and separate into new substatus

### DIFF
--- a/integration-test/test/2_handler-commands.bats
+++ b/integration-test/test/2_handler-commands.bats
@@ -132,7 +132,7 @@ teardown(){
     push_settings '
     {
         "protocol": "tcp",
-        "port": 443
+        "port": 8080
     }' ''
     run start_container
     echo "$output"

--- a/integration-test/webserver/main.go
+++ b/integration-test/webserver/main.go
@@ -34,8 +34,8 @@ func main() {
 	var shouldExitOnEmptyHealthStates = len(healthStates) > 0
 
 	httpMutex := http.NewServeMux()
-	httpServer := http.Server{Addr: ":8080", Handler: httpMutex}
-	httpsServer := http.Server{Addr: ":443", Handler: httpMutex}
+	httpServer := http.Server{Addr: ":8080"}
+	httpsServer := http.Server{Addr: ":443"}
 
 	// sends json resonse body with application health state expected by extension
 	// looks at the first state in the healthStates array and dequeues that element after its iterated
@@ -92,6 +92,13 @@ func main() {
 		}
 	})
 
+	httpServer.Handler = httpMutex
+	httpsServer.Handler = httpMutex
+
+	log.Printf("Starting http server...")
 	go httpServer.ListenAndServe()
-	httpsServer.ListenAndServeTLS("webservercert.pem", "webserverkey.pem")
+	log.Printf("Starting https server...")
+	log.Fatal(httpsServer.ListenAndServeTLS("webservercert.pem", "webserverkey.pem"))
+	log.Printf("Servers stopped...")
+	log.Printf("Finished serving health states: %v", originalHealthStates)
 }

--- a/integration-test/webserver/main.go
+++ b/integration-test/webserver/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
-	"fmt"
 	"time"
 )
 
@@ -32,7 +32,7 @@ func main() {
 	originalHealthStates := strings.Split(*states, ",")
 	healthStates := strings.Split(*states, ",")
 	var shouldExitOnEmptyHealthStates = len(healthStates) > 0
-	
+
 	httpMutex := http.NewServeMux()
 	httpServer := http.Server{Addr: ":8080", Handler: httpMutex}
 	httpsServer := http.Server{Addr: ":443", Handler: httpMutex}
@@ -49,30 +49,30 @@ func main() {
 			statusCode *= 100
 			if len(strArr) > 1 {
 				stateFlag := string(strArr[1])
-				
+
 				switch stateFlag {
-					case TimeoutFlag:
-						log.Printf("Sleeping for %d seconds", TimeoutInSeconds)
-						time.Sleep(TimeoutInSeconds * time.Second)
+				case TimeoutFlag:
+					log.Printf("Sleeping for %d seconds", TimeoutInSeconds)
+					time.Sleep(TimeoutInSeconds * time.Second)
 
-					case ApplicationHealthStateMissingFlag:
-						log.Printf("Sending response with missing app health state")
-						response["Hello"] = "World"
+				case ApplicationHealthStateMissingFlag:
+					log.Printf("Sending response with missing app health state")
+					response["Hello"] = "World"
 
-					case InvalidApplicationHealthStateValueFlag:
-						log.Printf("Sending response with invalid app health state")
-						response[ApplicationHealthStateResponseKey] = "Hello!"
+				case InvalidApplicationHealthStateValueFlag:
+					log.Printf("Sending response with invalid app health state")
+					response[ApplicationHealthStateResponseKey] = "Hello!"
 
-					default:
-						log.Printf("Sending response with app health state: %s", stateMap[stateFlag])
-						response[ApplicationHealthStateResponseKey] = stateMap[stateFlag]
+				default:
+					log.Printf("Sending response with app health state: %s", stateMap[stateFlag])
+					response[ApplicationHealthStateResponseKey] = stateMap[stateFlag]
 				}
 			} else {
 				log.Printf("Sending no response body with status code %v", statusCode)
 			}
 		}
 		healthStates = healthStates[1:]
-			
+
 		w.WriteHeader(statusCode)
 		w.Header().Set("Content-Type", "application/json")
 		resp, err := json.Marshal(response)

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -94,25 +94,25 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 		gracePeriodStartTime      = time.Now()
 	)
 
-	appHealthStatusSubstatusItem := SubstatusItem {
-		Name: SubstatusKeyNameAppHealthStatus,
+	appHealthStatusSubstatusItem := SubstatusItem{
+		Name:   SubstatusKeyNameAppHealthStatus,
 		Status: Healthy.GetStatusType(),
-		FormattedMessage: FormattedMessage {
-			Lang: "en",
+		FormattedMessage: FormattedMessage{
+			Lang:    "en",
 			Message: Healthy.GetSubstatusMessage(),
 		},
 	}
 
-	applicationHealthStateSubstatusItem := SubstatusItem {
-		Name: SubstatusKeyNameApplicationHealthState,
+	applicationHealthStateSubstatusItem := SubstatusItem{
+		Name:   SubstatusKeyNameApplicationHealthState,
 		Status: Healthy.GetStatusType(),
-		FormattedMessage: FormattedMessage {
-			Lang: "en",
+		FormattedMessage: FormattedMessage{
+			Lang:    "en",
 			Message: string(Healthy),
 		},
 	}
 
-	substatuses := []SubstatusItem {
+	substatuses := []SubstatusItem{
 		appHealthStatusSubstatusItem,
 		applicationHealthStateSubstatusItem,
 	}
@@ -146,7 +146,7 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 		// Only increment if it's a repeat of the previous
 		if prevState == state {
 			numConsecutiveProbes++
-		// Log stage changes and also reset consecutive count to 1 as a new state was observed
+			// Log stage changes and also reset consecutive count to 1 as a new state was observed
 		} else {
 			ctx.Log("event", "Health state changed to "+strings.ToLower(string(state)))
 			numConsecutiveProbes = 1
@@ -163,11 +163,11 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 				prevState = probe.healthStatusAfterGracePeriodExpires()
 				numConsecutiveProbes = 1
 				committedState = Empty
-			// If grace period has not expired, check if we have consecutive valid probes
+				// If grace period has not expired, check if we have consecutive valid probes
 			} else if (numConsecutiveProbes == numberOfProbes) && (state != probe.healthStatusAfterGracePeriodExpires()) {
 				ctx.Log("event", fmt.Sprintf("No longer honoring grace period - successful probes. Time elapsed = %v", timeElapsed))
 				honorGracePeriod = false
-			// Application will be in Initializing state since we have not received consecutive valid health states
+				// Application will be in Initializing state since we have not received consecutive valid health states
 			} else {
 				ctx.Log("event", fmt.Sprintf("Honoring grace period. Time elapsed = %v", timeElapsed))
 				state = Initializing
@@ -180,14 +180,14 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 				ctx.Log("event", fmt.Sprintf("Committed health state is %s", strings.ToLower(string(committedState))))
 			}
 			// Only reset if we've observed consecutive probes in order to preserve previous observations when handling grace period
-			if (numConsecutiveProbes == numberOfProbes) {
+			if numConsecutiveProbes == numberOfProbes {
 				numConsecutiveProbes = 0
 			}
 		}
 
 		substatuses[0].Status = committedState.GetStatusType()
 		substatuses[0].FormattedMessage.Message = committedState.GetSubstatusMessage()
-		
+
 		substatuses[1].Status = committedState.GetStatusType()
 		substatuses[1].FormattedMessage.Message = string(committedState)
 

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -94,6 +94,29 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 		gracePeriodStartTime      = time.Now()
 	)
 
+	appHealthStatusSubstatusItem := SubstatusItem {
+		Name: SubstatusKeyNameAppHealthStatus,
+		Status: Healthy.GetStatusType(),
+		FormattedMessage: FormattedMessage {
+			Lang: "en",
+			Message: Healthy.GetSubstatusMessage(),
+		},
+	}
+
+	applicationHealthStateSubstatusItem := SubstatusItem {
+		Name: SubstatusKeyNameApplicationHealthState,
+		Status: Healthy.GetStatusType(),
+		FormattedMessage: FormattedMessage {
+			Lang: "en",
+			Message: string(Healthy),
+		},
+	}
+
+	substatuses := []SubstatusItem {
+		appHealthStatusSubstatusItem,
+		applicationHealthStateSubstatusItem,
+	}
+
 	if !honorGracePeriod {
 		ctx.Log("event", "Grace period not set")
 	} else {
@@ -162,7 +185,13 @@ func enable(ctx *log.Context, h vmextension.HandlerEnvironment, seqNum int) (str
 			}
 		}
 
-		err = reportStatusWithSubstatus(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, committedState.GetStatusType(), SubstatusKeyNameAppHealthStatus, committedState.GetSubstatusMessage(), committedState)
+		substatuses[0].Status = committedState.GetStatusType()
+		substatuses[0].FormattedMessage.Message = committedState.GetSubstatusMessage()
+		
+		substatuses[1].Status = committedState.GetStatusType()
+		substatuses[1].FormattedMessage.Message = string(committedState)
+
+		err = reportStatusWithSubstatuses(ctx, h, seqNum, StatusSuccess, "enable", statusMessage, substatuses)
 		if err != nil {
 			ctx.Log("error", err)
 		}

--- a/main/constants.go
+++ b/main/constants.go
@@ -1,7 +1,7 @@
 package main
 
 const (
-	SubstatusKeyNameAppHealthStatus   			= "AppHealthStatus"
-	SubstatusKeyNameApplicationHealthState   	= "ApplicationHealthState"
-	ApplicationHealthStateResponseKey 			= "ApplicationHealthState"
+	SubstatusKeyNameAppHealthStatus        = "AppHealthStatus"
+	SubstatusKeyNameApplicationHealthState = "ApplicationHealthState"
+	ApplicationHealthStateResponseKey      = "ApplicationHealthState"
 )

--- a/main/constants.go
+++ b/main/constants.go
@@ -1,6 +1,7 @@
 package main
 
 const (
-	SubstatusKeyNameAppHealthStatus   = "AppHealthStatus"
-	ApplicationHealthStateResponseKey = "ApplicationHealthState"
+	SubstatusKeyNameAppHealthStatus   			= "AppHealthStatus"
+	SubstatusKeyNameApplicationHealthState   	= "ApplicationHealthState"
+	ApplicationHealthStateResponseKey 			= "ApplicationHealthState"
 )

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -84,12 +84,12 @@ func (h handlerSettings) validate() error {
 // publicSettings is the type deserialized from public configuration section of
 // the extension handler. This should be in sync with publicSettingsSchema.
 type publicSettings struct {
-	Protocol             string `json:"protocol"`
-	Port                 int    `json:"port,int"`
-	RequestPath          string `json:"requestPath"`
-	IntervalInSeconds    int    `json:"intervalInSeconds,int"`
-	NumberOfProbes       int    `json:"numberOfProbes,int"`
-	GracePeriod 		 int    `json:"gracePeriod,int"`
+	Protocol          string `json:"protocol"`
+	Port              int    `json:"port,int"`
+	RequestPath       string `json:"requestPath"`
+	IntervalInSeconds int    `json:"intervalInSeconds,int"`
+	NumberOfProbes    int    `json:"numberOfProbes,int"`
+	GracePeriod       int    `json:"gracePeriod,int"`
 }
 
 // protectedSettings is the type decoded and deserialized from protected

--- a/main/health.go
+++ b/main/health.go
@@ -26,6 +26,8 @@ const (
 
 func (p HealthStatus) GetStatusType() StatusType {
 	switch p {
+	case Initializing:
+		return StatusTransitioning
 	case Unknown:
 		return StatusError
 	default:

--- a/main/health.go
+++ b/main/health.go
@@ -58,9 +58,9 @@ func NewHealthProbe(ctx *log.Context, cfg *handlerSettings) HealthProbe {
 
 	switch cfg.protocol() {
 	case "tcp":
-		p = &TcpHealthProbe {
-				Address: "localhost:" + strconv.Itoa(cfg.port()),
-			}
+		p = &TcpHealthProbe{
+			Address: "localhost:" + strconv.Itoa(cfg.port()),
+		}
 		ctx.Log("event", "creating tcp probe targeting "+p.address())
 	case "http":
 		fallthrough
@@ -141,7 +141,7 @@ func (p *HttpHealthProbe) evaluate(ctx *log.Context) (HealthStatus, error) {
 	if err != nil {
 		return Unknown, err
 	}
-	
+
 	req.Header.Set("User-Agent", "ApplicationHealthExtension/1.0")
 	resp, err := p.HttpClient.Do(req)
 	// non-2xx status code doesn't return err

--- a/main/reportstatus.go
+++ b/main/reportstatus.go
@@ -24,9 +24,11 @@ func reportStatus(ctx *log.Context, hEnv vmextension.HandlerEnvironment, seqNum 
 	return nil
 }
 
-func reportStatusWithSubstatus(ctx *log.Context, hEnv vmextension.HandlerEnvironment, seqNum int, t StatusType, op string, msg string, subType StatusType, subName string, subMessage string, subHealthState HealthStatus) error {
+func reportStatusWithSubstatuses(ctx *log.Context, hEnv vmextension.HandlerEnvironment, seqNum int, t StatusType, op string, msg string, substatuses []SubstatusItem) error {
 	s := NewStatus(t, op, msg)
-	s.AddSubstatus(subType, subName, subMessage, subHealthState)
+	for _, substatus := range substatuses {
+		s.AddSubstatusItem(substatus)
+	}
 	if err := s.Save(hEnv.HandlerEnvironment.StatusFolder, seqNum); err != nil {
 		ctx.Log("event", "failed to save handler status", "error", err)
 		return errors.Wrap(err, "failed to save handler status")

--- a/main/status.go
+++ b/main/status.go
@@ -38,15 +38,10 @@ type FormattedMessage struct {
 	Message string `json:"message"`
 }
 
-type AdditionalProperties struct {
-	ApplicationHealthState HealthStatus `json:"applicationHealthState"`
-}
-
 type SubstatusItem struct {
 	Name                 string               `json:"name"`
 	Status               StatusType           `json:"status"`
 	FormattedMessage     FormattedMessage     `json:"formattedMessage"`
-	AdditionalProperties AdditionalProperties `json:"additionalProperties"`
 }
 
 func NewStatus(t StatusType, operation, message string) StatusReport {
@@ -70,19 +65,21 @@ func NewStatus(t StatusType, operation, message string) StatusReport {
 
 func (r StatusReport) AddSubstatus(t StatusType, name, message string, state HealthStatus) {
 	if len(r) > 0 {
-		r[0].Status.SubstatusList = []SubstatusItem{
-			{
-				Name: name,
-				Status: t,
-				FormattedMessage: FormattedMessage {
-					Lang: "en",
-					Message: message,
-				},
-				AdditionalProperties: AdditionalProperties {
-					ApplicationHealthState: state,
-				},
+		substatusItem := SubstatusItem {
+			Name: name,
+			Status: t,
+			FormattedMessage: FormattedMessage {
+				Lang: "en",
+				Message: message,
 			},
 		}
+		r[0].Status.SubstatusList = append(r[0].Status.SubstatusList, substatusItem)
+	}
+}
+
+func (r StatusReport) AddSubstatusItem(substatus SubstatusItem) {
+	if len(r) > 0 {
+		r[0].Status.SubstatusList = append(r[0].Status.SubstatusList, substatus)
 	}
 }
 

--- a/main/status.go
+++ b/main/status.go
@@ -39,23 +39,23 @@ type FormattedMessage struct {
 }
 
 type SubstatusItem struct {
-	Name                 string               `json:"name"`
-	Status               StatusType           `json:"status"`
-	FormattedMessage     FormattedMessage     `json:"formattedMessage"`
+	Name             string           `json:"name"`
+	Status           StatusType       `json:"status"`
+	FormattedMessage FormattedMessage `json:"formattedMessage"`
 }
 
 func NewStatus(t StatusType, operation, message string) StatusReport {
 	now := time.Now().UTC().Format(time.RFC3339)
 	return []StatusItem{
 		{
-			Version: 1.0,
+			Version:      1.0,
 			TimestampUTC: now,
-			Status: Status {
-				Operation: operation,
+			Status: Status{
+				Operation:                   operation,
 				ConfigurationAppliedTimeUTC: now,
 				Status: t,
 				FormattedMessage: FormattedMessage{
-					Lang: "en",
+					Lang:    "en",
 					Message: message,
 				},
 			},
@@ -65,11 +65,11 @@ func NewStatus(t StatusType, operation, message string) StatusReport {
 
 func (r StatusReport) AddSubstatus(t StatusType, name, message string, state HealthStatus) {
 	if len(r) > 0 {
-		substatusItem := SubstatusItem {
-			Name: name,
+		substatusItem := SubstatusItem{
+			Name:   name,
 			Status: t,
-			FormattedMessage: FormattedMessage {
-				Lang: "en",
+			FormattedMessage: FormattedMessage{
+				Lang:    "en",
 				Message: message,
 			},
 		}


### PR DESCRIPTION
Since adding a new property is not allowed due to guest agents filtering unrecognized properties and existing schema not being generic enough to lead to a change, we must utilize existing substatus schema to avoid guest agent changes.

Remove additionalProperties and separate into new substatus