### PR TITLE
Increase max settle time to 240 seconds

### DIFF
--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -11,10 +11,10 @@ import (
 var (
 	errTcpMustNotIncludeRequestPath    = errors.New("'requestPath' cannot be specified when using 'tcp' protocol")
 	errTcpConfigurationMustIncludePort = errors.New("'port' must be specified when using 'tcp' protocol")
-	errProbeSettleTimeExceedsThreshold = errors.New("Probe settle time (intervalInSeconds * numberOfProbes) cannot exceed 120 seconds")
+	errProbeSettleTimeExceedsThreshold = errors.New("Probe settle time (intervalInSeconds * numberOfProbes) cannot exceed 240 seconds")
 	defaultIntervalInSeconds           = 5
 	defaultNumberOfProbes              = 1
-	maximumProbeSettleTime             = 120
+	maximumProbeSettleTime             = 240
 )
 
 // handlerSettings holds the configuration of the extension handler.

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -16,9 +16,9 @@ func Test_handlerSettingsValidate(t *testing.T) {
 		protectedSettings{},
 	}.validate())
 
-	// probe settle time should be less than 120 seconds
+	// probe settle time cannot exceed 240 seconds
 	require.Equal(t, errProbeSettleTimeExceedsThreshold, handlerSettings{
-		publicSettings{Protocol: "http", IntervalInSeconds: 60, NumberOfProbes: 3},
+		publicSettings{Protocol: "http", IntervalInSeconds: 60, NumberOfProbes: 5},
 		protectedSettings{},
 	}.validate())
 


### PR DESCRIPTION
Increase max settle time 120 -> 240 seconds.
Update unit test for scenario for trying to have total settle time of 180 -> 300 should result in error