### PR TITLE
Makefile: Always build static binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,16 @@ binary: clean
 	  echo "GOPATH is not set"; \
 	  exit 1; \
 	fi
-	GOOS=linux GOARCH=amd64 govvv build -v \
+	# Set CGO_ENABLED=0 for static binaries, note that another approach might be needed if dependencies change
+	# (see https://github.com/golang/go/issues/26492 for using an external linker if CGO is required)
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 govvv build -v \
 	  -ldflags "-X main.Version=`grep -E -m 1 -o '<Version>(.*)</Version>' misc/manifest.xml | awk -F">" '{print $$2}' | awk -F"<" '{print $$1}'`" \
 	  -o $(BINDIR)/$(BIN) ./main
 	cp ./misc/applicationhealth-shim ./$(BINDIR)
-	GOOS=linux GOARCH=amd64 govvv build -v \
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 govvv build -v \
 	  -ldflags "-X main.Version=`grep -E -m 1 -o '<Version>(.*)</Version>' misc/manifest.xml | awk -F">" '{print $$2}' | awk -F"<" '{print $$1}'`" \
 	  -o $(TESTBINDIR)/$(WEBSERVERBIN) ./integration-test/webserver
-	GOOS=linux GOARCH=arm64 govvv build -v \
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 govvv build -v \
 	  -ldflags "-X main.Version=`grep -E -m 1 -o '<Version>(.*)</Version>' misc/manifest.xml | awk -F">" '{print $$2}' | awk -F"<" '{print $$1}'`" \
 	  -o $(BINDIR)/$(BIN_ARM64) ./main 
 clean:


### PR DESCRIPTION
Static binaries were use for arm64 through the cross-compilation but not for amd64. This added a dependency on some system libraries that the host OS should provide, such as glibc with a certain minimal version.

To align the amd64 with the arm64 binary and reduce requirements for the host OS, always build static binaries. The result was checked with running "file bin/applicationhealth-*".