### PR TITLE
Make integration tests pass again

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04, ubuntu-18.04]
+        os: [ubuntu-latest, ubuntu-20.04]
     
     runs-on: ${{ matrix.os }}
 
@@ -45,18 +45,7 @@ jobs:
         godep restore
       working-directory: ${{ env.repo_root }}
 
-    - name: Install Bats
-      run: |
-        sudo apt install npm
-        sudo npm install -g bats
-
-    - name: Install Docker
-      run: |
-        sudo apt-get install runc
-        sudo apt-get install containerd
-        sudo apt-get install docker.io
-
-    - name: Formatting 
+    - name: Formatting
       continue-on-error: true
       run: test -z "$(gofmt -s -l -w $(find . -type f -name '*.go' -not -path './vendor/*') | tee /dev/stderr)"
       working-directory: ${{ env.repo_root }}
@@ -71,7 +60,7 @@ jobs:
       run: test -z "$(go vet -v $(go list ./... | grep -v '/vendor/') | tee /dev/stderr)"
       working-directory: ${{ env.repo_root }}
 
-    - name: Unit Tests
+    - name: Run Unit Tests
       continue-on-error: true
       run: go list ./... | grep -v '/vendor/' | xargs go test -v -cover
       working-directory: ${{ env.repo_root }}
@@ -79,8 +68,19 @@ jobs:
     - name: Build Binaries
       run: make binary
       working-directory: ${{ env.repo_root }}
+
+    - name: Install Integration Test Dependencies - Bats
+      run: |
+        sudo apt install npm
+        sudo npm install -g bats
+
+    - name: Install Integration Test Dependencies - Docker
+      run: |
+        sudo apt-get install runc
+        sudo apt-get install containerd
+        sudo apt-get install docker.io
     
-    - name: Generate Webserver Credentials
+    - name: Generate Integration Test Webserver Credentials
       run: |
         openssl rand -out ~/.rnd 2048
         openssl genrsa -out testbin/webserverkey.pem 2048

--- a/integration-test/test/1_basic.bats
+++ b/integration-test/test/1_basic.bats
@@ -17,7 +17,7 @@ load test_helper
 @test "meta: can start the test container" {
     run in_tmp_container fake-waagent
     echo "$output"
-    [ "$output" = "Usage: /sbin/fake-waagent <handlerCommand>" ]
+    [ "$output" = "Usage: /usr/sbin/fake-waagent <handlerCommand>" ]
     [ "$status" -eq 1 ]
 }
 

--- a/integration-test/test/2_handler-commands.bats
+++ b/integration-test/test/2_handler-commands.bats
@@ -11,7 +11,7 @@ teardown(){
 }
 
 @test "handler command: install - creates the data dir" {
-    mk_container sh -c "fake-waagent install"
+    mk_container sh -c "fake-waagent install && sleep 2"
     push_settings '' ''
 
     run start_container

--- a/integration-test/test/2_handler-commands.bats
+++ b/integration-test/test/2_handler-commands.bats
@@ -11,10 +11,13 @@ teardown(){
 }
 
 @test "handler command: install - creates the data dir" {
-    run in_container fake-waagent install
+    mk_container sh -c "fake-waagent install"
+    push_settings '' ''
+
+    run start_container
     echo "$output"
     [ "$status" -eq 0 ]
-    [[ "$output" = *event=installed* ]]
+    [[ "$output" = *'event=installed'* ]]
 
     diff="$(container_diff)"
     echo "$diff"

--- a/integration-test/test/test_helper.bash
+++ b/integration-test/test/test_helper.bash
@@ -29,12 +29,12 @@ in_container() {
     set -e
     rm_container
     mk_container "$@"
-    echo "Starting test container...">&2
     start_container
 }
 
 start_container() {
-    docker start --attach $TEST_CONTAINER
+    echo "Starting test container...">&2 && \
+        docker start --attach $TEST_CONTAINER
 }
 
 container_diff() {
@@ -174,6 +174,6 @@ verify_substatus_item() {
     # $4 substatus.formattedMessage.message
     FMT='"name": "'%s'",\s+"status": "'%s'",\s+"formattedMessage": {\s+"lang": "en",\s+"message": "'%s'"'
     printf -v SUBSTATUS "$FMT" "$2" "$3" "$4"
-    echo "Searching status file for: $SUBSTATUS"
+    echo "Searching status file for substatus item: $SUBSTATUS"
     echo "$1" | egrep -z "$SUBSTATUS"
 }

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM ubuntu:20.04
 
 RUN apt-get -qqy update && \
 	apt-get -qqy install jq openssl ca-certificates && \


### PR DESCRIPTION
#Changes
1. debian:jessie is deprecated, changing to ubuntu:20.04.
2. Some UTs now fail on this distro, even though it passes locally, editing to pass for both.
3. Nits