### PR TITLE
App Health Extension v2: Increase maximum grace period to 4 hours.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,6 +19,9 @@ jobs:
       repo_root : ${{ github.workspace }}/go/src/github.com/applicationhealth-extension-linux
 
     steps:
+    - name: Apt-Get Update
+      run: sudo apt-get update
+      
     - name: Setup Go
       uses: actions/setup-go@v3
 

--- a/main/schema.go
+++ b/main/schema.go
@@ -48,7 +48,7 @@ const (
       "description": "The amount of time in seconds the application will default to 'Initializing' state if no valid health state is observed numberOfProbes consecutive times.",
       "type": "integer",
       "minimum": 5,
-      "maximum": 7200
+      "maximum": 14400
     }
   },
   "additionalProperties": false

--- a/main/schema_test.go
+++ b/main/schema_test.go
@@ -98,3 +98,59 @@ func TestValidateProtectedSettings_unrecognizedField(t *testing.T) {
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "Additional property alien is not allowed")
 }
+
+func TestValidatePublicSettings_gracePeriod(t *testing.T) {
+	testCases := []struct {
+		name        string
+		input       string
+		expectedErr string
+	}{
+		{
+			name:        "invalid type",
+			input:       `{"gracePeriod": "foo"}`,
+			expectedErr: "Invalid type. Expected: integer, given: string",
+		},
+		{
+			name:        "invalid value (equal to 0)",
+			input:       `{"gracePeriod": 0}`,
+			expectedErr: "gracePeriod: Must be greater than or equal to 5",
+		},
+		{
+			name:        "invalid value (less than min value)",
+			input:       `{"gracePeriod": 4}`,
+			expectedErr: "gracePeriod: Must be greater than or equal to 5",
+		},
+		{
+			name:        "invalid value (greater than max value)",
+			input:       `{"gracePeriod": 15000}`,
+			expectedErr: "gracePeriod: Must be less than or equal to 14400",
+		},
+		{
+			name:        "valid value (equal to min value)",
+			input:       `{"gracePeriod": 5}`,
+			expectedErr: "",
+		},
+		{
+			name:        "valid value (between min and max value)",
+			input:       `{"gracePeriod": 7201}`,
+			expectedErr: "",
+		},
+		{
+			name:        "valid value (equal to max value)",
+			input:       `{"gracePeriod": 14400}`,
+			expectedErr: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePublicSettings(tc.input)
+			if tc.expectedErr == "" {
+				require.Nil(t, err)
+			} else {
+				require.NotNil(t, err)
+				require.Contains(t, err.Error(), tc.expectedErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Changes
-  Increase maximum grace period to 4 hours.
- Added new UTs to valid Grace Period Config Properties.