### PR TITLE
App Health Extension v2: Added Support TLS 1.3, added Parallel test e…

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,9 +3,13 @@ name: Go
 on:
   workflow_dispatch:
   push:
-    branches: [ "master" ]
+    branches: 
+      - master
+      - feature/*
   pull_request:
-    branches: [ "master" ]
+    branches: 
+      - master
+      - feature/*
 
 jobs:
   build:
@@ -48,6 +52,10 @@ jobs:
         sudo apt install npm
         sudo npm install -g bats
 
+    - name: Install Parallel
+      run: |
+        sudo apt install parallel
+
     - name: Install Docker
       run: |
         sudo apt-get install runc
@@ -85,6 +93,26 @@ jobs:
         openssl req -new -x509 -sha256 -key testbin/webserverkey.pem -out testbin/webservercert.pem -days 3650 -subj '/CN=www.contoso.com/O=Contoso LTD./C=US'
       working-directory: ${{ env.repo_root }}
 
-    - name: Run Integration Tests
-      run: sudo bats integration-test/test
+    - name: Run Sequential Integration Tests
+      continue-on-error: true
+      run: |
+        mkdir -p integration-test/test/sequential/.bats/run-logs/
+        sudo bats integration-test/test/sequential -T --trace
+      working-directory: ${{ env.repo_root }}
+
+    - name: Retry Failing Sequential Integration Tests
+      run: |
+        sudo bats integration-test/test/sequential --filter-status failed -T --trace
+      working-directory: ${{ env.repo_root }}
+
+    - name: Run Parallel Integration Tests
+      continue-on-error: true
+      run: |
+        mkdir -p integration-test/test/parallel/.bats/run-logs/
+        sudo bats integration-test/test/parallel --jobs 10 -T --trace
+      working-directory: ${{ env.repo_root }}
+
+    - name: Retry Failing Parallel Integration Tests
+      run: |
+        sudo bats integration-test/test/parallel --filter-status failed -T --trace
       working-directory: ${{ env.repo_root }}

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -38,5 +38,5 @@ root:
 
 ```
 make binary
-bats integration-test/test
+./integration-test/run.sh
 ```

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -1,3 +1,11 @@
-openssl genrsa -out testbin/webserverkey.pem 2048
-openssl req -new -x509 -sha256 -key testbin/webserverkey.pem -out testbin/webservercert.pem -days 3650 -subj '/CN=www.contoso.com/O=Contoso LTD./C=US'
-sudo bats integration-test/test/
+#!/bin/bash
+source integration-test/test/test_helper.bash
+create_certificate
+# Run Sequential Integration Tests
+sudo bats integration-test/test/sequential -T --trace
+err1=$?
+# Run Parallel Integration Tests
+sudo bats integration-test/test/parallel  --jobs 10 -T --trace
+err2=$?
+delete_certificate
+exit $((err1 + err2))

--- a/integration-test/test/parallel/2_handler-commands.bats
+++ b/integration-test/test/parallel/2_handler-commands.bats
@@ -1,17 +1,19 @@
 #!/usr/bin/env bats
 
-load test_helper
+load ../test_helper
 
 setup(){
     build_docker_image
+    container_name="handler-command_$BATS_TEST_NUMBER"
 }
 
 teardown(){
     rm -rf "$certs_dir"
+    cleanup
 }
 
 @test "handler command: install - creates the data dir" {
-    mk_container sh -c "fake-waagent install && sleep 2"
+    mk_container $container_name sh -c "fake-waagent install && sleep 2"
     push_settings '' ''
 
     run start_container
@@ -25,7 +27,7 @@ teardown(){
 }
 
 @test "handler command: enable - default" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '' ''
 
     run start_container
@@ -39,7 +41,7 @@ teardown(){
 }
 
 @test "handler command: enable twice, process exits cleanly" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable && rm /var/lib/waagent/Extension/status/0.status && fake-waagent enable && wait-for-enable status"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable && rm /var/lib/waagent/Extension/status/0.status && fake-waagent enable && wait-for-enable status"
     push_settings '' ''
 
     run start_container
@@ -59,7 +61,7 @@ teardown(){
 }
 
 @test "handler command: enable - validates json schema" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '{"badElement":null}' ''
    
     run start_container
@@ -68,7 +70,7 @@ teardown(){
 }
 
 @test "handler command: enable - failed tcp probe" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '
     {
         "protocol": "tcp",
@@ -84,7 +86,7 @@ teardown(){
 }
 
 @test "handler command: enable - failed http probe" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '
     {
         "protocol": "http",
@@ -112,7 +114,7 @@ teardown(){
 }
 
 @test "handler command: enable - failed https probe" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '
     {
         "protocol": "https",
@@ -140,7 +142,7 @@ teardown(){
 }
 
 @test "handler command: enable - healthy tcp probe" {
-    mk_container sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable"
+    mk_container $container_name sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '
     {
         "protocol": "tcp",
@@ -156,7 +158,7 @@ teardown(){
 }
 
 @test "handler command: enable - healthy http probe" {
-    mk_container sh -c "webserver -args=2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -176,7 +178,7 @@ teardown(){
 }
 
 @test "handler command: enable - https unknown after 10 seconds" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable && sleep 10 && rm /var/lib/waagent/Extension/status/0.status && wait-for-enable status"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable && sleep 10 && rm /var/lib/waagent/Extension/status/0.status && wait-for-enable status"
     push_settings '
     {
         "protocol": "https",
@@ -209,7 +211,7 @@ teardown(){
 }
 
 @test "handler command: enable - unknown http probe - no response body" {
-    mk_container sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -236,7 +238,7 @@ teardown(){
 }
 
 @test "handler command: enable - unknown http probe - no response body - prefixing requestPath with a slash" {
-    mk_container sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -264,7 +266,7 @@ teardown(){
 }
 
 @test "handler command: enable - unknown https probe - no response body" {
-    mk_container sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver_shim && fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "https",
@@ -291,7 +293,7 @@ teardown(){
 }
 
 @test "handler command: enable - numofprobes with states = unk,unk" {
-    mk_container sh -c "webserver -args=3,4 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=3,4 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -321,7 +323,7 @@ teardown(){
 }
 
 @test "handler command: enable - numofprobes with states = h,h,unk,unk" {
-    mk_container sh -c "webserver -args=2h,2h,4,4 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h,2h,4,4 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -357,7 +359,7 @@ teardown(){
 }
 
 @test "handler command: enable - numofprobes with states = h,h,unk,unk,h" {
-    mk_container sh -c "webserver -args=2h,2h,4,4,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h,2h,4,4,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -394,7 +396,7 @@ teardown(){
 }
 
 @test "handler command: enable - numofprobes with states = h,h,unk,unk,h,h" {
-    mk_container sh -c "webserver -args=2h,2h,4,4,2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h,2h,4,4,2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",

--- a/integration-test/test/parallel/3_rich-states.bats
+++ b/integration-test/test/parallel/3_rich-states.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+
+load ../test_helper
+
+setup(){
+    build_docker_image
+    container_name="rich-states_$BATS_TEST_NUMBER"
+}
+
+teardown(){
+    rm -rf "$certs_dir"
+    cleanup
+}
+
+@test "handler command: enable - rich states - invalid app health state results in unknown" {
+    mk_container $container_name sh -c "webserver -args=2h,2h,2i,2h,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    push_settings '
+    {
+        "protocol": "http",
+        "requestPath": "health",
+        "port": 8080,
+        "numberOfProbes": 2,
+        "intervalInSeconds": 5
+    }' ''
+    run start_container
+
+    echo "$output"
+    [[ "$output" == *'Grace period set to 10s'* ]]
+    [[ "$output" == *'Honoring grace period'* ]]
+    [[ "$output" == *'No longer honoring grace period - successful probes'* ]]
+    
+    enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
+    
+    expectedTimeDifferences=(0 5 5 5 5 5)
+    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
+
+    expectedStateLogs=(
+        "Health state changed to healthy"
+        "Committed health state is initializing"
+        "Committed health state is healthy"
+        "Health state changed to unknown"
+        "Health state changed to healthy"
+        "Health state changed to unknown"
+        "Committed health state is unknown"
+    )
+    verify_states "$enableLog" "${expectedStateLogs[@]}"
+
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
+    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
+}
+
+@test "handler command: enable - rich states - basic states = m,h,h,u,u,i,i" {
+    mk_container $container_name sh -c "webserver -args=2,2h,2h,2u,2u,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    push_settings '
+    {
+        "protocol": "http",
+        "requestPath": "health",
+        "port": 8080,
+        "numberOfProbes": 2,
+        "intervalInSeconds": 5
+    }' ''
+    run start_container
+
+    echo "$output"
+    [[ "$output" == *'Grace period set to 10s'* ]]
+    [[ "$output" == *'Honoring grace period'* ]]
+    [[ "$output" == *'No longer honoring grace period - expired'* ]]
+
+    enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
+    
+    expectedTimeDifferences=(0 5 5 5 5 5 5)
+    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
+   
+    expectedStateLogs=(
+        "Health state changed to unknown"
+        "Committed health state is initializing"
+        "Health state changed to healthy"
+        "Committed health state is unknown"
+        "Health state changed to unhealthy"
+        "Committed health state is unhealthy"
+        "Health state changed to unknown"
+        "Committed health state is unknown"
+    )
+    verify_states "$enableLog" "${expectedStateLogs[@]}"
+    
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
+    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
+}
+
+@test "handler command: enable - rich states - alternating states=i,h,h,i,h,u,h,i,h" {
+    mk_container $container_name sh -c "webserver -args=2i,2h,2h,2i,2h,2u,2h,2i,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    push_settings '
+    {
+        "protocol": "http",
+        "requestPath": "health",
+        "port": 8080,
+        "numberOfProbes": 2,
+        "intervalInSeconds": 5
+    }' ''
+    run start_container
+
+    echo "$output"
+    [[ "$output" == *'Grace period set to 10s'* ]]
+    [[ "$output" == *'Honoring grace period'* ]]
+    [[ "$output" == *'No longer honoring grace period - expired'* ]]
+
+    enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
+
+    expectedTimeDifferences=(0 5 5 10 5 5 5 5)
+    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
+    
+    expectedStateLogs=(
+        "Health state changed to unknown"
+        "Committed health state is initializing"
+        "Health state changed to healthy"
+        "Committed health state is unknown"
+        "Health state changed to healthy"
+        "Health state changed to unhealthy"
+        "Health state changed to healthy"
+        "Health state changed to unknown"
+        "Health state changed to healthy"
+    )
+    verify_states "$enableLog" "${expectedStateLogs[@]}"
+
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
+    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
+}
+
+@test "handler command: enable - rich states - endpoint timeout results in unknown" {
+    mk_container $container_name sh -c "webserver -args=2h,2t,2t & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    push_settings '
+    {
+        "protocol": "http",
+        "requestPath": "health",
+        "port": 8080,
+        "numberOfProbes": 2,
+        "intervalInSeconds": 5
+    }' ''
+    run start_container
+
+    echo "$output"
+    [[ "$output" == *'Grace period set to 10s'* ]]
+    [[ "$output" == *'Honoring grace period'* ]]
+    [[ "$output" == *'No longer honoring grace period - expired'* ]]
+
+    enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
+
+    expectedTimeDifferences=(0 35 0)
+    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
+    
+    expectedStateLogs=(
+        "Health state changed to healthy"
+        "Committed health state is initializing"
+        "Health state changed to unknown"
+        "Committed health state is unknown"
+    )
+    verify_states "$enableLog" "${expectedStateLogs[@]}"
+
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
+    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
+}

--- a/integration-test/test/parallel/4_grace-period.bats
+++ b/integration-test/test/parallel/4_grace-period.bats
@@ -1,17 +1,19 @@
 #!/usr/bin/env bats
 
-load test_helper
+load ../test_helper
 
 setup(){
     build_docker_image
+    container_name="grace-period_$BATS_TEST_NUMBER"
 }
 
 teardown(){
     rm -rf "$certs_dir"
+    cleanup
 }
 
 @test "handler command: enable - grace period defaults even when set to 0" {
-    mk_container sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
+    mk_container $container_name sh -c "fake-waagent install && fake-waagent enable && wait-for-enable"
     push_settings '
     {
         "protocol": "http",
@@ -28,7 +30,7 @@ teardown(){
 }
 
 @test "handler command: enable - honor grace period - http 2 probes" {
-    mk_container sh -c "webserver -args=2i,2h,2u,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2i,2h,2u,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -65,7 +67,7 @@ teardown(){
 }
 
 @test "handler command: enable - honor grace period - unresponsive http probe with numberOfProbes=1" {
-    mk_container sh -c "webserver -args=2t,2t,2t & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2t,2t,2t & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -94,7 +96,7 @@ teardown(){
 }
 
 @test "handler command: enable - bypass grace period - consecutive valid health states" {
-    mk_container sh -c "webserver -args=2i,2h,2u,2h,2h,2,2 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2i,2h,2u,2h,2h,2,2 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -134,7 +136,7 @@ teardown(){
 }
 
 @test "handler command: enable - bypass grace period - state change behavior retained" {
-    mk_container sh -c "webserver -args=2i,2h,2u,2h,2h,2u,2u,2h,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2i,2h,2u,2h,2h,2u,2u,2h,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -177,7 +179,7 @@ teardown(){
 }
 
 @test "handler command: enable - bypass grace period - larger numberOfProbes, consecutive rich states" {
-    mk_container sh -c "webserver -args=2i,2i,2i,2i,2h,2u,2h,2u,2u,2h,2h,2h,2h,2u,2i,2i,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2i,2i,2i,2i,2h,2u,2h,2u,2u,2h,2h,2h,2h,2u,2i,2i,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -220,7 +222,7 @@ teardown(){
 }
 
 @test "handler command: enable - bypass / grace period expires - fail to bypass and expiration results in unknown" {
-    mk_container sh -c "webserver -args=2u,2,2i,2i,2h,2u,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2u,2,2i,2i,2h,2u,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -259,7 +261,7 @@ teardown(){
 }
 
 @test "handler command: enable - grace period expires - additional alternating health states" {
-    mk_container sh -c "webserver -args=2i,2u,2i,2u,2i,2u,2h,2u,2h,2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2i,2u,2i,2u,2i,2u,2h,2u,2h,2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",

--- a/integration-test/test/parallel/5_custom-metrics.bats
+++ b/integration-test/test/parallel/5_custom-metrics.bats
@@ -1,18 +1,20 @@
 #!/usr/bin/env bats
 
-load test_helper
+load ../test_helper
 
 setup(){
     build_docker_image
+    container_name="custom-metrics_$BATS_TEST_NUMBER"
 }
 
 teardown(){
     rm -rf "$certs_dir"
+    cleanup
 }
 
 
 @test "handler command: enable - custom metrics - not sending custom metrics is not seen in status file" {
-    mk_container sh -c "webserver -args=2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -44,7 +46,7 @@ teardown(){
 }
 
 @test "handler command: enable - custom metrics - sending null custom metrics is omitted and not seen in status file " {
-    mk_container sh -c "webserver -args=2h-null,2h-null,2u-null,2u-null & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h-null,2h-null,2u-null,2u-null & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -78,7 +80,7 @@ teardown(){
 }
 
 @test "handler command: enable - custom metrics - sending empty string custom metrics is omitted and not seen in status file " {
-    mk_container sh -c "webserver -args=2h-empty,2h-empty & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h-empty,2h-empty & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -110,7 +112,7 @@ teardown(){
 }
 
 @test "handler command: enable - custom metrics - sending empty json object in custom metrics appears in status file with error status" {
-    mk_container sh -c "webserver -args=2h-emptyobj,2h-emptyobj & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h-emptyobj,2h-emptyobj & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -142,7 +144,7 @@ teardown(){
 }
 
 @test "handler command: enable - custom metrics - sending invalid formatted custom metrics appears in status file with error status" {
-    mk_container sh -c "webserver -args=2h-invalid,2h-invalid & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h-invalid,2h-invalid & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -174,7 +176,7 @@ teardown(){
 }
 
 @test "handler command: enable - custom metrics - sending valid custom metrics is seen in status file" {
-    mk_container sh -c "webserver -args=2h-valid,2h-valid & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2h-valid,2h-valid & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",
@@ -206,7 +208,7 @@ teardown(){
 }
 
 @test "handler command: enable - custom metrics - sending valid custom metrics is seen in status file even if health is unknown" {
-    mk_container sh -c "webserver -args=2m-valid,2m-valid & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    mk_container $container_name sh -c "webserver -args=2m-valid,2m-valid & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
         "protocol": "http",

--- a/integration-test/test/parallel/6_tls-config.bats
+++ b/integration-test/test/parallel/6_tls-config.bats
@@ -1,99 +1,58 @@
 #!/usr/bin/env bats
 
-load test_helper
+load ../test_helper
 
 setup(){
     build_docker_image
+    container_name="tls-config_$BATS_TEST_NUMBER"
 }
 
 teardown(){
     rm -rf "$certs_dir"
+    cleanup
 }
 
-@test "handler command: enable - rich states - invalid app health state results in unknown" {
-    mk_container sh -c "webserver -args=2h,2h,2i,2h,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+@test "handler command: enable - Testing SSLv3" {
+    mk_container $container_name sh -c "webserver -args=2t,2t,2t -securityProtocol=ssl3.0 & fake-waagent install && fake-waagent enable && sleep 10 && wait-for-enable"
     push_settings '
     {
-        "protocol": "http",
+        "protocol": "https",
         "requestPath": "health",
-        "port": 8080,
+        "port": 4430,
         "numberOfProbes": 2,
         "intervalInSeconds": 5
     }' ''
     run start_container
-
     echo "$output"
+    # ApplicationHealth Extension should only Support from TLS 1.0 to TLS 1.3
+    # if only invalid Security Protocol is supported by the application like SSLv3 
+    # then the extension will receive a Standard TLS error. 
     [[ "$output" == *'Grace period set to 10s'* ]]
-    [[ "$output" == *'Honoring grace period'* ]]
-    [[ "$output" == *'No longer honoring grace period - successful probes'* ]]
-    
-    enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
-    
-    expectedTimeDifferences=(0 5 5 5 5 5)
-    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
-
-    expectedStateLogs=(
-        "Health state changed to healthy"
-        "Committed health state is initializing"
-        "Committed health state is healthy"
-        "Health state changed to unknown"
-        "Health state changed to healthy"
-        "Health state changed to unknown"
-        "Committed health state is unknown"
-    )
-    verify_states "$enableLog" "${expectedStateLogs[@]}"
-
-    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
-    verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
-    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
-}
-
-@test "handler command: enable - rich states - basic states = m,h,h,u,u,i,i" {
-    mk_container sh -c "webserver -args=2,2h,2h,2u,2u,2i,2i & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
-    push_settings '
-    {
-        "protocol": "http",
-        "requestPath": "health",
-        "port": 8080,
-        "numberOfProbes": 2,
-        "intervalInSeconds": 5
-    }' ''
-    run start_container
-
-    echo "$output"
-    [[ "$output" == *'Grace period set to 10s'* ]]
-    [[ "$output" == *'Honoring grace period'* ]]
+    [[ "$output" == *'remote error: tls: protocol version not supported'* ]]
     [[ "$output" == *'No longer honoring grace period - expired'* ]]
 
     enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
     
-    expectedTimeDifferences=(0 5 5 5 5 5 5)
-    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
-   
     expectedStateLogs=(
         "Health state changed to unknown"
         "Committed health state is initializing"
-        "Health state changed to healthy"
-        "Committed health state is unknown"
-        "Health state changed to unhealthy"
-        "Committed health state is unhealthy"
-        "Health state changed to unknown"
         "Committed health state is unknown"
     )
     verify_states "$enableLog" "${expectedStateLogs[@]}"
-    
+
     status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    echo $status_file
     verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
-    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
 }
 
-@test "handler command: enable - rich states - alternating states=i,h,h,i,h,u,h,i,h" {
-    mk_container sh -c "webserver -args=2i,2h,2h,2i,2h,2u,2h,2i,2h & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+
+@test "handler command: enable - Testing TLS 1.0 " {
+    mk_container $container_name sh -c "webserver -args=2i,2h,2h,2i,2h,2u,2h,2i,2h -securityProtocol=tls1.0 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
-        "protocol": "http",
+        "protocol": "https",
         "requestPath": "health",
-        "port": 8080,
+        "port": 4430,
         "numberOfProbes": 2,
         "intervalInSeconds": 5
     }' ''
@@ -127,13 +86,14 @@ teardown(){
     verify_substatus_item "$status_file" ApplicationHealthState error Unknown
 }
 
-@test "handler command: enable - rich states - endpoint timeout results in unknown" {
-    mk_container sh -c "webserver -args=2h,2t,2t & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+
+@test "handler command: enable - Testing TLS 1.1" {
+    mk_container $container_name sh -c "webserver -args=2i,2h,2h,2i,2h,2u,2h,2i,2h -securityProtocol=tls1.1 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
     push_settings '
     {
-        "protocol": "http",
+        "protocol": "https",
         "requestPath": "health",
-        "port": 8080,
+        "port": 4430,
         "numberOfProbes": 2,
         "intervalInSeconds": 5
     }' ''
@@ -146,14 +106,100 @@ teardown(){
 
     enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
 
-    expectedTimeDifferences=(0 35 0)
+    expectedTimeDifferences=(0 5 5 10 5 5 5 5)
     verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
     
     expectedStateLogs=(
-        "Health state changed to healthy"
-        "Committed health state is initializing"
         "Health state changed to unknown"
+        "Committed health state is initializing"
+        "Health state changed to healthy"
         "Committed health state is unknown"
+        "Health state changed to healthy"
+        "Health state changed to unhealthy"
+        "Health state changed to healthy"
+        "Health state changed to unknown"
+        "Health state changed to healthy"
+    )
+    verify_states "$enableLog" "${expectedStateLogs[@]}"
+
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
+    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
+}
+
+
+@test "handler command: enable - Testing TLS 1.2" {
+    mk_container $container_name sh -c "webserver -args=2i,2h,2h,2i,2h,2u,2h,2i,2h -securityProtocol=tls1.2 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    push_settings '
+    {
+        "protocol": "https",
+        "requestPath": "health",
+        "port": 4430,
+        "numberOfProbes": 2,
+        "intervalInSeconds": 5
+    }' ''
+    run start_container
+
+    echo "$output"
+    [[ "$output" == *'Grace period set to 10s'* ]]
+    [[ "$output" == *'Honoring grace period'* ]]
+    [[ "$output" == *'No longer honoring grace period - expired'* ]]
+
+    enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
+
+    expectedTimeDifferences=(0 5 5 10 5 5 5 5)
+    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
+    
+    expectedStateLogs=(
+        "Health state changed to unknown"
+        "Committed health state is initializing"
+        "Health state changed to healthy"
+        "Committed health state is unknown"
+        "Health state changed to healthy"
+        "Health state changed to unhealthy"
+        "Health state changed to healthy"
+        "Health state changed to unknown"
+        "Health state changed to healthy"
+    )
+    verify_states "$enableLog" "${expectedStateLogs[@]}"
+
+    status_file="$(container_read_file /var/lib/waagent/Extension/status/0.status)"
+    verify_substatus_item "$status_file" AppHealthStatus error "Application found to be unhealthy"
+    verify_substatus_item "$status_file" ApplicationHealthState error Unknown
+}
+
+@test "handler command: enable - Testing TLS 1.3" {
+    mk_container $container_name sh -c "webserver -args=2i,2h,2h,2i,2h,2u,2h,2i,2h -securityProtocol=tls1.3 & fake-waagent install && fake-waagent enable && wait-for-enable webserverexit"
+    push_settings '
+    {
+        "protocol": "https",
+        "requestPath": "health",
+        "port": 4430,
+        "numberOfProbes": 2,
+        "intervalInSeconds": 5
+    }' ''
+    run start_container
+
+    echo "$output"
+    [[ "$output" == *'Grace period set to 10s'* ]]
+    [[ "$output" == *'Honoring grace period'* ]]
+    [[ "$output" == *'No longer honoring grace period - expired'* ]]
+
+    enableLog="$(echo "$output" | grep 'operation=enable' | grep state)"
+
+    expectedTimeDifferences=(0 5 5 10 5 5 5 5)
+    verify_state_change_timestamps "$enableLog" "${expectedTimeDifferences[@]}"
+    
+    expectedStateLogs=(
+        "Health state changed to unknown"
+        "Committed health state is initializing"
+        "Health state changed to healthy"
+        "Committed health state is unknown"
+        "Health state changed to healthy"
+        "Health state changed to unhealthy"
+        "Health state changed to healthy"
+        "Health state changed to unknown"
+        "Health state changed to healthy"
     )
     verify_states "$enableLog" "${expectedStateLogs[@]}"
 

--- a/integration-test/test/sequential/1_basic.bats
+++ b/integration-test/test/sequential/1_basic.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-load test_helper
+load ../test_helper
 
 @test "meta: docker is installed" {
     run docker version

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/Azure/azure-docker-extension/pkg/vmextension"
-	"github.com/go-kit/kit/log"
-	"github.com/pkg/errors"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/Azure/azure-docker-extension/pkg/vmextension"
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
 )
 
 type cmdFunc func(ctx *log.Context, hEnv vmextension.HandlerEnvironment, seqNum int) (msg string, err error)

--- a/main/health_test.go
+++ b/main/health_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHttpHealthProbe_DefaultHttpPort(t *testing.T) {
+	protocol := "http"
+	requestPath := "/test"
+	port := 80
+
+	probe := NewHttpHealthProbe(protocol, requestPath, port)
+
+	require.NotNil(t, probe, "Expected HttpHealthProbe, got nil")
+	require.NotNil(t, probe.HttpClient, "Expected HttpClient, got nil")
+	require.Equal(t, "http://localhost/test", probe.Address, "Expected address to be http://localhost/test")
+}
+
+func TestNewHttpHealthProbe_DefaultHttpsPort(t *testing.T) {
+	protocol := "https"
+	requestPath := "/test"
+	port := 443
+
+	probe := NewHttpHealthProbe(protocol, requestPath, port)
+
+	require.NotNil(t, probe, "Expected HttpHealthProbe, got nil")
+	require.NotNil(t, probe.HttpClient, "Expected HttpClient, got nil")
+	require.Equal(t, "https://localhost/test", probe.Address, "Expected address to be https://localhost/test")
+}
+
+func TestNewHttpHealthProbe_NonDefaultPort(t *testing.T) {
+	protocol := "http"
+	requestPath := "/test"
+	port := 8080
+
+	probe := NewHttpHealthProbe(protocol, requestPath, port)
+
+	require.NotNil(t, probe, "Expected HttpHealthProbe, got nil")
+	require.NotNil(t, probe.HttpClient, "Expected HttpClient, got nil")
+	require.Equal(t, "http://localhost:8080/test", probe.Address, "Expected address to be http://localhost:8080/test")
+}
+
+func TestConstructAddress_RequestPath(t *testing.T) {
+	// Testing leading slash
+	var (
+		protocol    = "https"
+		requestPath = "/test"
+		port        = 8080
+	)
+
+	address := constructAddress(protocol, port, requestPath)
+	require.Equal(t, "https://localhost:8080/test", address, "Expected address to be http://localhost:8080/test")
+
+	// Testing non-leading slash
+	protocol = "http"
+	requestPath = "test"
+	port = 80
+
+	address = constructAddress(protocol, port, requestPath)
+	require.Equal(t, "http://localhost/test", address, "Expected address to be http://localhost/test")
+}
+
+func TestNewHttpHealthProbe_RequestPath(t *testing.T) {
+	// Testing leading slash
+	var (
+		protocol    = "http"
+		requestPath = "/test"
+		port        = 80
+	)
+	probe := NewHttpHealthProbe(protocol, requestPath, port)
+
+	require.NotNil(t, probe, "Expected HttpHealthProbe, got nil")
+	require.NotNil(t, probe.HttpClient, "Expected HttpClient, got nil")
+	require.Equal(t, "http://localhost/test", probe.Address, "Expected address to be http://localhost/test")
+
+	// Testing non-leading slash
+	protocol = "http"
+	requestPath = "test"
+	port = 10400
+	probe = NewHttpHealthProbe(protocol, requestPath, port)
+
+	require.NotNil(t, probe, "Expected HttpHealthProbe, got nil")
+	require.NotNil(t, probe.HttpClient, "Expected HttpClient, got nil")
+	require.Equal(t, "http://localhost:10400/test", probe.Address, "Expected address to be http://localhost:10400/test")
+}


### PR DESCRIPTION
…xecution and updated GitHub Workflow. (#38)

* - Added min and max TLS version support.
- Included Support for TLS 1.3
- Minimum  TLS 1.1 enforced.

* - Added bash function to create and delete certificates.
- Modified run.sh script to use the create and delete certificate functions.
- Added new instructions to run integration tests in README.md

* - Added 3 Integration tests to test each version of TLS.
- Added tlsVersion flag for webserver input.
- Added TLS Config for https webserver.
- Added helper functions to get TLS Version and Health State.
- Changed port of https server from 443 to 4430.

* - refactored NewHttpHealthProbe function.

* - changed min version to TLS 1.0

* - Test all TLS versions, including SSLv3
- Parallelize integration tests.

* - modified go.yml to use run.sh

* - Changes Flag to securityProtocol and updated Comments.

* -Added dynamic container names to bats tests.

* - TLS Config set to Defaults but tested.

* cleanup logic for created container.

* Only basic.bats tests are ran sequentially

* Only basic.bats tests are ran sequentially

* Attempt to fix go.yml

* Revert: TLS Config set to Defaults but tested

* TLS Max Version set to Default.

* Added small comments and verbose logs for integration tests.

* Try fix go workflow

* Update github workflow for v2/main and v2/develop.

* Try Add sequential and parallel integration tests with retry option.

* Try Fix: "Try Add sequential and parallel integration tests with retry option."

* Try Fix: "Try Fix: "Try Add sequential and parallel integration tests with retry option.""

* Update branch names in go.yml workflow

* Refactor health probe address construction

* Add While loop to finf unique docker image and Added Clarification comments.

* Refactor integration test job names

* capture error from run.sh script

* Fixed repeated Assertions on SSLv3 test

* Refactor health test function names and added new tests to validate request path.

* Remove unnecessary code in health.go

* nit changes to getHealthStatus

* Refactor integration test scripts for better organization and parallelization

* Fix github workflow integration test directory paths.

* Update branch restrictions for push and pull_request workflows

<details><summary>Details</summary>
<p>

This pull request includes a variety of changes to improve the functionality and usability of the codebase. The most important changes include adding new SSL/TLS integration tests, adding new functionality to generate unique names for Docker images and to clean up containers and images, and adding new functions to create and delete self-signed certificates for use in custom metrics tests.

Main interface changes:

* <a href="diffhunk://#diff-db5ccf1b6f97761a2e7e8cb4c16754861128734a0bda7520aa4b7d51b530cbe2R9-R59">`integration-test/test/test_helper.bash`</a>: Added new functionality to generate unique names for Docker images and to clean up containers and images, as well as new functions to create and delete self-signed certificates for use in custom metrics tests. <a href="diffhunk://#diff-db5ccf1b6f97761a2e7e8cb4c16754861128734a0bda7520aa4b7d51b530cbe2R9-R59">[1]</a> <a href="diffhunk://#diff-db5ccf1b6f97761a2e7e8cb4c16754861128734a0bda7520aa4b7d51b530cbe2R216-R231">[2]</a>
* <a href="diffhunk://#diff-2422cb6e5f570a2a3eeb5388f7e0fcc644727dfd0d34911de35e83a268f1d2efL132-L156">`main/health.go`</a>: Added a new function to construct URL strings, modified the `NewHttpHealthProbe` function to support TLS1.0, removed an unnecessary line, and added a new import to parse URLs. <a href="diffhunk://#diff-2422cb6e5f570a2a3eeb5388f7e0fcc644727dfd0d34911de35e83a268f1d2efL132-L156">[1]</a> <a href="diffhunk://#diff-2422cb6e5f570a2a3eeb5388f7e0fcc644727dfd0d34911de35e83a268f1d2efR122-R140">[2]</a> <a href="diffhunk://#diff-2422cb6e5f570a2a3eeb5388f7e0fcc644727dfd0d34911de35e83a268f1d2efL74">[3]</a> <a href="diffhunk://#diff-2422cb6e5f570a2a3eeb5388f7e0fcc644727dfd0d34911de35e83a268f1d2efL11-R14">[4]</a>

Testing improvements:

* <a href="diffhunk://#diff-0b7866b89415c284625b6e2964f04078e4145ea93ecf38dc0061246c76522048R1-R209">`integration-test/test/parallel/6_tls-config.bats`</a>: Added SSL/TLS integration tests to check application health with different protocol versions.
* <a href="diffhunk://#diff-ace417b47e816a44cf3b6f6248e72453a46d9e6043f19aea9d39212e852cc373L5-R11">`main/cmds.go`</a>: The order of imports was changed.
* <a href="diffhunk://#diff-77c13d6986727b4b39067ec6227ed255794736d6bb875c3a3b294a043d7c3b83R1-R87">`main/health_test.go`</a>: Added new tests to check the behavior of `NewHttpHealthProbe` and `constructAddress` functions in the `main` package.

Other changes:

* <a href="diffhunk://#diff-caca036aaca1d574d9aad6849f0d9d5ca148b6204592115da2fea6aa1a953e01L1-R11">`integration-test/run.sh`</a>: Updated file path for `test_helper` in `integration-test/run.sh`.
* <a href="diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL6-R12">`.github/workflows/go.yml`</a>: Automated testing for feature branches was enabled by modifying the `go.yml` file to include all branches starting with `feature/`. <a href="diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL6-R12">[1]</a> <a href="diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL88-R117">[2]</a>
* <a href="diffhunk://#diff-168ec243b031e7d090611ba34499a07ab648c7150e2cbf6220f37a71c280ab4cR5">`integration-test/webserver/main.go`</a>: Added new functions and modified `main()` function to support secure communication over the internet using `crypto/tls` package and added a new command line argument `securityProtocol` to specify the security protocol to use for the HTTPS server. <a href="diffhunk://#diff-168ec243b031e7d090611ba34499a07ab648c7150e2cbf6220f37a71c280ab4cR5">[1]</a> <a href="diffhunk://#diff-168ec243b031e7d090611ba34499a07ab648c7150e2cbf6220f37a71c280ab4cL111-R112">[2]</a> <a href="diffhunk://#diff-168ec243b031e7d090611ba34499a07ab648c7150e2cbf6220f37a71c280ab4cR151-R197">[3]</a> <a href="diffhunk://#diff-168ec243b031e7d090611ba34499a07ab648c7150e2cbf6220f37a71c280ab4cL177-L179">[4]</a>
* <a href="diffhunk://#diff-81c362d167240c77cd39a0678f9bf4de3b93ecd0a7ed07c5eb780173530532ecL41-R41">`integration-test/README.md`</a>: The command to run integration tests has been updated in `integration-test/README.md` to use `./integration-test/run.sh` instead of `bats` to ensure the correct command is used.

</p>
</details> 