### PR TITLE
Add debug flag when running vmwatch

### DIFF
--- a/main/vmWatch.go
+++ b/main/vmWatch.go
@@ -24,7 +24,7 @@ const (
 	MaxCpuQuota               = 1        // 1% cpu
 	MaxMemoryInBytes          = 40000000 // 40MB
 	HoursBetweenRetryAttempts = 3
-	CGroupV2PeriodMs          = 1000000 // 1 second	
+	CGroupV2PeriodMs          = 1000000 // 1 second
 )
 
 const (
@@ -36,7 +36,7 @@ const (
 
 const (
 	AllowVMWatchCgroupAssignmentFailureVariableName string = "ALLOW_VMWATCH_CGROUP_ASSIGNMENT_FAILURE"
-	RunningInDevContainerVariableName string = "RUNNING_IN_DEV_CONTAINER"
+	RunningInDevContainerVariableName               string = "RUNNING_IN_DEV_CONTAINER"
 )
 
 func (p VMWatchStatus) GetStatusType() StatusType {
@@ -221,6 +221,7 @@ func setupVMWatchCommand(s *vmWatchSettings, hEnv HandlerEnvironment) (*exec.Cmd
 	}
 
 	args := []string{"--config", GetVMWatchConfigFullPath(processDirectory)}
+	args = append(args, "--debug")
 	args = append(args, "--heartbeat-file", GetVMWatchHeartbeatFilePath(hEnv))
 
 	if s.SignalFilters != nil {


### PR DESCRIPTION
VMWatch logs verbose (operational) trace logs into 2 places:
1. EventsFolder contains logs with "Error" level only. These logs will go to kusto by Guest Agent.
2. LogFolder contains all logs above debug level by default. Adding the debug flag in this PR will make debug level logs to be included in the LogFolder. The logs in LogFolder is configured with a retention policy, so we don't need to worry debug level logs utilize too much VM space