### PR TITLE
Passing Extension Version to VMWatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ endif
 	ln -sf /var/lib/waagent/webserver /sbin/webserver
 	ln -sf /var/lib/waagent/webserver_shim /sbin/webserver_shim
 	cp misc/HandlerManifest.json /var/lib/waagent/Extension/
+	cp misc/manifest.xml /var/lib/waagent/Extension/
 	cp misc/applicationhealth-shim /var/lib/waagent/Extension/bin/
 	cp bin/applicationhealth-extension /var/lib/waagent/Extension/bin
 	mkdir -p /var/log/azure/Extension/events

--- a/integration-test/test/parallel/7_vmwatch.bats
+++ b/integration-test/test/parallel/7_vmwatch.bats
@@ -5,6 +5,8 @@ load ../test_helper
 setup(){
     build_docker_image
     container_name="vmwatch_$BATS_TEST_NUMBER"
+    extension_version=$(get_extension_version)
+    echo "extension version: $extension_version"
 }
 
 teardown(){
@@ -95,6 +97,7 @@ teardown(){
     [[ "$output" == *'Setup VMWatch command: /var/lib/waagent/Extension/bin/VMWatch/vmwatch_linux_amd64'* ]]
     [[ "$output" == *'VMWatch process started'* ]]
     [[ "$output" == *'--config /var/lib/waagent/Extension/bin/VMWatch/vmwatch.conf'* ]]
+    [[ "$output" == *"--apphealth-version $extension_version"* ]]
     [[ "$output" == *'Env: [SIGNAL_FOLDER=/var/log/azure/Extension/events VERBOSE_LOG_FILE_FULL_PATH=/var/log/azure/Extension/VE.RS.ION/vmwatch.log]'* ]]
     [[ "$output" == *'VMWatch is running'* ]]
 
@@ -130,6 +133,7 @@ teardown(){
     [[ "$output" == *'VMWatch process started'* ]]
     [[ "$output" == *'--config /var/lib/waagent/Extension/bin/VMWatch/vmwatch.conf'* ]]
     [[ "$output" == *'--disabled-signals clockskew:az_storage_blob:process:dns'* ]]
+    [[ "$output" == *"--apphealth-version $extension_version"* ]]
     [[ "$output" == *'Env: [ABC=abc BCD=bcd SIGNAL_FOLDER=/var/log/azure/Extension/events VERBOSE_LOG_FILE_FULL_PATH=/var/log/azure/Extension/VE.RS.ION/vmwatch.log]'* ]]
     [[ "$output" == *'VMWatch is running'* ]]
 
@@ -175,6 +179,7 @@ teardown(){
     [[ "$output" == *'VMWatch process started'* ]]
     [[ "$output" == *'--config /var/lib/waagent/Extension/bin/VMWatch/vmwatch.conf'* ]]
     [[ "$output" == *'--disabled-signals clockskew:az_storage_blob:process:dns'* ]]
+    [[ "$output" == *"--apphealth-version $extension_version"* ]]
     [[ "$output" == *'Env: [SIGNAL_FOLDER=/var/log/azure/Extension/events VERBOSE_LOG_FILE_FULL_PATH=/var/log/azure/Extension/VE.RS.ION/vmwatch.log]'* ]]
     [[ "$output" == *'VMWatch is running'* ]]
 
@@ -230,6 +235,7 @@ teardown(){
     [[ "$output" == *'--disabled-tags Accuracy'* ]]
     [[ "$output" == *'--enabled-optional-signals simple'* ]]
     [[ "$output" == *'--env-attributes OutboundConnectivityEnabled=true'* ]]
+    [[ "$output" == *"--apphealth-version $extension_version"* ]]
     [[ "$output" == *'Env: [SIGNAL_FOLDER=/var/log/azure/Extension/events VERBOSE_LOG_FILE_FULL_PATH=/var/log/azure/Extension/VE.RS.ION/vmwatch.log]'* ]]
     [[ "$output" == *'VMWatch is running'* ]]
 

--- a/integration-test/test/test_helper.bash
+++ b/integration-test/test/test_helper.bash
@@ -265,3 +265,9 @@ delete_certificate() {
     rm -f testbin/webserverkey.pem
     rm -f testbin/webservercert.pem
 }
+
+get_extension_version() {
+    # extract version from manifest.xml
+    version=$(awk -F'[<>]' '/<Version>/ {print $3}' misc/manifest.xml)
+    echo $version
+}

--- a/main/constants.go
+++ b/main/constants.go
@@ -23,4 +23,6 @@ const (
 	VMWatchVerboseLogFileName = "vmwatch.log"
 	VMWatchDefaultTests       = "disk_io:outbound_connectivity:clockskew:az_storage_blob"
 	VMWatchMaxProcessAttempts = 3
+
+	ExtensionManifestFileName = "manifest.xml"
 )

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -221,15 +221,23 @@ func GetExtensionManifest(filepath string) (ExtensionManifest, error) {
 	return manifest, nil
 }
 
+// Get Extension Version set at build time or from manifest file.
 func GetExtensionManifestVersion() (string, error) {
+	// First attempting to read the version set during build time.
+	v := GetExtensionVersion()
+	if v != "" {
+		return v, nil
+	}
+
+	// If the version is not set during build time, then reading it from the manifest file as fallback.
 	processDirectory, err := GetProcessDirectory()
 	if err != nil {
 		return "", err
 	}
 	processDirectory = filepath.Dir(processDirectory)
-	filepath := processDirectory + "/" + ExtensionManifestFileName
+	fp := filepath.Join(processDirectory, ExtensionManifestFileName)
 
-	manifest, err := GetExtensionManifest(filepath)
+	manifest, err := GetExtensionManifest(fp)
 	if err != nil {
 		return "", err
 	}

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"encoding/json"
+	"encoding/xml"
+	"os"
+	"path/filepath"
 
 	"github.com/Azure/azure-docker-extension/pkg/vmextension"
 	"github.com/go-kit/kit/log"
@@ -185,4 +188,50 @@ func toJSON(o map[string]interface{}) (string, error) {
 	}
 	b, err := json.Marshal(o)
 	return string(b), errors.Wrap(err, "failed to marshal into json")
+}
+
+type ExtensionManifest struct {
+	ProviderNameSpace   string `xml:"ProviderNameSpace"`
+	Type                string `xml:"Type"`
+	Version             string `xml:"Version"`
+	Label               string `xml:"Label"`
+	HostingResources    string `xml:"HostingResources"`
+	MediaLink           string `xml:"MediaLink"`
+	Description         string `xml:"Description"`
+	IsInternalExtension bool   `xml:"IsInternalExtension"`
+	IsJsonExtension     bool   `xml:"IsJsonExtension"`
+	SupportedOS         string `xml:"SupportedOS"`
+	CompanyName         string `xml:"CompanyName"`
+}
+
+func GetExtensionManifest(filepath string) (ExtensionManifest, error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return ExtensionManifest{}, err
+	}
+	defer file.Close()
+
+	decoder := xml.NewDecoder(file)
+	var manifest ExtensionManifest
+	err = decoder.Decode(&manifest)
+
+	if err != nil {
+		return ExtensionManifest{}, err
+	}
+	return manifest, nil
+}
+
+func GetExtensionManifestVersion() (string, error) {
+	processDirectory, err := GetProcessDirectory()
+	if err != nil {
+		return "", err
+	}
+	processDirectory = filepath.Dir(processDirectory)
+	filepath := processDirectory + "/" + ExtensionManifestFileName
+
+	manifest, err := GetExtensionManifest(filepath)
+	if err != nil {
+		return "", err
+	}
+	return manifest.Version, nil
 }

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -70,3 +70,34 @@ func Test_unMarshalPublicSetting(t *testing.T) {
 	require.Equal(t, true, h.publicSettings.VMWatchSettings.Enabled)
 	require.Equal(t, "https://testxyz.azurefd.net/config/disable-switch-config.json", h.publicSettings.VMWatchSettings.GlobalConfigUrl)
 }
+
+func Test_ExtensionManifestVersion(t *testing.T) {
+
+	currVersion := "2.0.8"
+	expectedManifest := ExtensionManifest{
+		ProviderNameSpace:   "Microsoft.ManagedServices",
+		Type:                "ApplicationHealthLinux",
+		Version:             currVersion,
+		Label:               "Microsoft Azure Application Health Extension for Linux Virtual Machines",
+		HostingResources:    "VmRole",
+		MediaLink:           "",
+		Description:         "Microsoft Azure Application Health Extension is an extension installed on a VM to periodically determine configured application health.",
+		IsInternalExtension: true,
+		IsJsonExtension:     true,
+		SupportedOS:         "Linux",
+		CompanyName:         "Microsoft",
+	}
+
+	currentManifest, err := GetExtensionManifest("../misc/manifest.xml")
+	require.Nil(t, err)
+	require.Equal(t, expectedManifest.Version, currentManifest.Version)
+	require.Equal(t, expectedManifest.Type, currentManifest.Type)
+	require.Equal(t, expectedManifest.Label, currentManifest.Label)
+	require.Equal(t, expectedManifest.HostingResources, currentManifest.HostingResources)
+	require.Equal(t, expectedManifest.MediaLink, currentManifest.MediaLink)
+	require.Equal(t, expectedManifest.Description, currentManifest.Description)
+	require.Equal(t, expectedManifest.IsInternalExtension, currentManifest.IsInternalExtension)
+	require.Equal(t, expectedManifest.IsJsonExtension, currentManifest.IsJsonExtension)
+	require.Equal(t, expectedManifest.SupportedOS, currentManifest.SupportedOS)
+	require.Equal(t, expectedManifest.CompanyName, currentManifest.CompanyName)
+}

--- a/main/handlersettings_test.go
+++ b/main/handlersettings_test.go
@@ -87,6 +87,8 @@ func Test_ExtensionManifestVersion(t *testing.T) {
 		SupportedOS:         "Linux",
 		CompanyName:         "Microsoft",
 	}
+	v := GetExtensionVersion()
+	require.Empty(t, v)
 
 	currentManifest, err := GetExtensionManifest("../misc/manifest.xml")
 	require.Nil(t, err)

--- a/main/version.go
+++ b/main/version.go
@@ -26,3 +26,7 @@ func DetailedVersionString() string {
 	// e.g. v2.2.0 git:03669cef-clean build:2016-07-22T16:22:26.556103000+00:00 go:go1.6.2
 	return fmt.Sprintf("v%s git:%s-%s build:%s %s", Version, GitCommit, GitState, BuildDate, runtime.Version())
 }
+
+func GetExtensionVersion() string {
+	return Version
+}

--- a/main/vmWatch.go
+++ b/main/vmWatch.go
@@ -273,6 +273,11 @@ func setupVMWatchCommand(s *vmWatchSettings, hEnv HandlerEnvironment) (*exec.Cmd
 		args = append(args, "--local")
 	}
 
+	extVersion, err := GetExtensionManifestVersion()
+	if err == nil {
+		args = append(args, "--apphealth-version", extVersion)
+	}
+
 	cmd := exec.Command(GetVMWatchBinaryFullPath(processDirectory), args...)
 
 	cmd.Env = GetVMWatchEnvironmentVariables(s.ParameterOverrides, hEnv)


### PR DESCRIPTION
This pull request introduces changes to enable reading and parsing of the extension manifest XML file. The most important change is that Extension Version will now be passed to VMWatch via the --apphealth-version argument flag.

Main changes:

* [`main/handlersettings_test.go`](diffhunk://#diff-b03af7a434e1d3021b3182c08e59d1dcc170482aabe3afeb3545851fd534e384R73-R103): Added a UT `Test_ExtensionManifestVersion` to check if the extension manifest version matches the expected version.
* [`main/handlersettings.go`](diffhunk://#diff-f8ae33e4c69620dbc2523794f5240aa34ad618e11e155fec37c03a0c2e8b2b8cR5-R7): Enabled reading and parsing of the extension manifest XML file by importing necessary packages and defining the required struct and functions. [[1]](diffhunk://#diff-f8ae33e4c69620dbc2523794f5240aa34ad618e11e155fec37c03a0c2e8b2b8cR5-R7) [[2]](diffhunk://#diff-f8ae33e4c69620dbc2523794f5240aa34ad618e11e155fec37c03a0c2e8b2b8cR192-R237)
* [`main/vmWatch.go`](diffhunk://#diff-c4cc39742c3af7a2d043b6b901afc8f5510ce7889de849aedb68e143349e5408R276-R280): Added a command argument to pass the version of the extension manifest being used.

Other changes:

* [`main/constants.go`](diffhunk://#diff-745cb9b2e31b8e151535b5cc6b9afc4aa5f12fbecc0240d32a66b22a88282413R26-R27): Added a new constant `ExtensionManifestFileName` to hold the name of the extension manifest XML file.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R51): The extension manifest XML file is now copied to a specific directory to ensure it is available for the extension to use.