### PR TITLE
Fixing bug to successfully kill AppHealth Gracefully & VMWatch. 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.18-bullseye
+FROM mcr.microsoft.com/devcontainers/go:1.21-bullseye
 
 RUN apt-get -qqy update && \
 	apt-get -qqy install jq openssl ca-certificates && \
@@ -16,3 +16,32 @@ RUN mkdir -p /var/lib/waagent && \
 COPY extension-settings.json /var/lib/waagent/Extension/config/0.settings
 # install go tools we need for build
 RUN go install github.com/ahmetb/govvv@latest
+
+# Install npm
+RUN apt-get update && \
+    apt-get install -y npm
+    
+# Updating npm to the latest version
+RUN npm cache clean -f && npm install -g n && n stable
+
+# Install dev enviroment dependencies
+RUN npm install bats -g
+
+#Install Bats-Assert and Bats-Support
+RUN npm install -g https://github.com/bats-core/bats-assert && \
+        npm install -g https://github.com/bats-core/bats-support
+
+# Install Parallel 
+RUN apt-get install -y parallel
+
+# Install Docker
+RUN apt-get install runc -y && \
+        apt-get install containerd -y && \
+        apt-get install docker.io -y
+
+# Install Docker Engine
+RUN curl -fsSL https://test.docker.com -o test-docker.sh && \
+        sh test-docker.sh
+
+# Creating ENV variables
+ENV CUSTOM_BATS_LIB_PATH /usr/local/lib/node_modules

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,14 +23,22 @@
             "settings": {},
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": [
-                "golang.go"
-            ]
+                "golang.go",
+                "ms-azuretools.vscode-docker"
+            ],
+            "recommendations": [
+                "GitHub.copilot",
+                "GitHub.copilot-chat",
+                "GitHub.vscode-pull-request-github"
+            ] 
         }
     },
     "remoteUser": "root",
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "echo hello",
-    "mounts": [ ]
+    "postCreateCommand": "go mod download && echo hello",
+    "mounts": [ 
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" 
+    ]
 
     // // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [5000, 5001],B

--- a/.devcontainer/extension-settings.json
+++ b/.devcontainer/extension-settings.json
@@ -8,7 +8,7 @@
                     "port": 8080,
                     "numberOfProbes": 1,
                     "intervalInSeconds": 5,
-                    "gracePeriod": 600,
+                    "gracePeriod": 10,
                     "vmWatchSettings": {
                         "enabled": true,
                         "signalFilters": {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,5 +27,16 @@
             ],
             "preLaunchTask": "make devcontainer"
         },
+        {
+            "name": "devcontainer run - enable NOBUILD",
+            "type": "go",
+            "request": "launch",
+            "mode": "exec",
+            "program": "/var/lib/waagent/Extension/bin/applicationhealth-extension",
+            "cwd": "${workspaceFolder}",
+            "args" : [
+                "enable"
+            ]
+        }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,14 @@
             "preLaunchTask": "make devcontainer"
         },
         {
+            "name": "Run integration tests",
+            "type": "node-terminal",
+            "request": "launch",
+            "command": "./integration-test/run.sh",
+            "cwd": "${workspaceFolder}",
+            "preLaunchTask": "make binary"
+        },
+        {
             "name": "devcontainer run - enable NOBUILD",
             "type": "go",
             "request": "launch",

--- a/integration-test/env/extension-test-helpers.sh
+++ b/integration-test/env/extension-test-helpers.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -uex
+
+force_kill_apphealth() {
+    app_health_pid=$(ps -ef | grep "applicationhealth-extension" | grep -v grep | grep -v tee | awk '{print $2}')
+
+    if [ -z "$app_health_pid" ]; then
+        echo "Applicationhealth extension is not running" > /var/log/azure/Extension/force-kill-extension.txt
+        return 0
+    fi
+    echo "Killing the applicationhealth extension forcefully" > /var/log/azure/Extension/force-kill-extension.txt
+    kill -9 $app_health_pid
+
+    output=$(check_running_processes)
+    if [ "$output" == "Applicationhealth and VMWatch are not running" ]; then
+        echo "$output" >> /var/log/azure/Extension/force-kill-extension.txt
+        echo "Successfully killed the apphealth extension" >> /var/log/azure/Extension/force-kill-extension.txt
+        echo "Successfully killed the VMWatch extension" >> /var/log/azure/Extension/force-kill-extension.txt
+    else
+        echo "$output" >> /var/log/azure/Extension/force-kill-extension.txt
+        echo "Failed to kill the apphealth extension" >> /var/log/azure/Extension/force-kill-extension.txt
+    fi
+    
+}
+
+check_running_processes() {
+    # check if the applicationhealth extension is running
+    # echo "Checking if the AppHealth Extension and VMWatch are running"
+    local output=$(ps -ef | grep -e "applicationhealth-extension" -e "vmwatch_linux_amd64" | grep -v grep | grep -v tee)
+    if [ -z "$output" ]; then
+        echo "Applicationhealth and VMWatch are not running"
+    else
+        if [ -n "$(echo $output | grep "applicationhealth-extension")" ]; then
+            echo "Applicationhealth is running"
+        fi
+        if [ -n "$(echo $output | grep "vmwatch_linux_amd64")" ]; then
+            echo "VMWatch is running"
+        fi
+        echo "$output"
+    fi
+}

--- a/integration-test/env/extension-test-helpers.sh
+++ b/integration-test/env/extension-test-helpers.sh
@@ -1,31 +1,30 @@
 #!/bin/bash
 set -uex
+logFilePath="/var/log/azure/Extension/force-kill-extension.txt"
 
 force_kill_apphealth() {
     app_health_pid=$(ps -ef | grep "applicationhealth-extension" | grep -v grep | grep -v tee | awk '{print $2}')
 
     if [ -z "$app_health_pid" ]; then
-        echo "Applicationhealth extension is not running" > /var/log/azure/Extension/force-kill-extension.txt
+        echo "Applicationhealth extension is not running" > $logFilePath
         return 0
     fi
-    echo "Killing the applicationhealth extension forcefully" > /var/log/azure/Extension/force-kill-extension.txt
+    echo "Killing the applicationhealth extension forcefully" >> $logFilePath
     kill -9 $app_health_pid
 
     output=$(check_running_processes)
     if [ "$output" == "Applicationhealth and VMWatch are not running" ]; then
         echo "$output" >> /var/log/azure/Extension/force-kill-extension.txt
-        echo "Successfully killed the apphealth extension" >> /var/log/azure/Extension/force-kill-extension.txt
-        echo "Successfully killed the VMWatch extension" >> /var/log/azure/Extension/force-kill-extension.txt
+        echo "Successfully killed the apphealth extension" >> $logFilePath
+        echo "Successfully killed the VMWatch extension" >> $logFilePath
     else
         echo "$output" >> /var/log/azure/Extension/force-kill-extension.txt
-        echo "Failed to kill the apphealth extension" >> /var/log/azure/Extension/force-kill-extension.txt
+        echo "Failed to kill the apphealth extension" >> $logFilePath
     fi
     
 }
 
 check_running_processes() {
-    # check if the applicationhealth extension is running
-    # echo "Checking if the AppHealth Extension and VMWatch are running"
     local output=$(ps -ef | grep -e "applicationhealth-extension" -e "vmwatch_linux_amd64" | grep -v grep | grep -v tee)
     if [ -z "$output" ]; then
         echo "Applicationhealth and VMWatch are not running"

--- a/integration-test/run.sh
+++ b/integration-test/run.sh
@@ -21,10 +21,10 @@ done
 source integration-test/test/test_helper.bash
 create_certificate
 # Run Sequential Integration Tests
-sudo bats integration-test/test/sequential -T --trace 
+bats integration-test/test/sequential -T --trace 
 err1=$?
 # Run Parallel Integration Tests
-sudo bats integration-test/test/parallel  --jobs 10 -T --trace $FILTER
+bats integration-test/test/parallel  --jobs 10 -T --trace $FILTER
 err2=$?
 delete_certificate
 exit $((err1 + err2))

--- a/integration-test/test/test_helper.bash
+++ b/integration-test/test/test_helper.bash
@@ -271,3 +271,21 @@ get_extension_version() {
     version=$(awk -F'[<>]' '/<Version>/ {print $3}' misc/manifest.xml)
     echo $version
 }
+# Accepted Kill Signals SIGINT SIGTERM
+kill_apphealth_extension_gracefully() {
+    # kill the applicationhealth extension gracefully
+    # echo "Printing the process list Before killing the applicationhealth extension"
+    ps -ef | grep -e "applicationhealth-extension" -e "vmwatch_linux_amd64" | grep -v grep
+    kill_signal=$1
+    [[ $kill_signal == "SIGINT" || $kill_signal == "SIGTERM" ]] || { echo "Invalid signal: $kill_signal"; return 1; }
+    app_health_pid=$(ps -ef | grep "applicationhealth-extension" | grep -v grep | grep -v tee | awk '{print $2}')
+    if [ -z "$app_health_pid" ]; then
+        echo "Applicationhealth extension is not running"
+        return 0
+    fi
+    # echo "Killing applicationhealth extension with signal: $kill_signal"
+    # echo "PID: $app_health_pid"
+    kill -s $kill_signal $app_health_pid
+    # echo "Printing the process list after killing the applicationhealth extension"
+    ps -ef | grep -e "applicationhealth-extension" -e "vmwatch_linux_amd64" | grep -v grep
+}

--- a/main/main.go
+++ b/main/main.go
@@ -35,7 +35,7 @@ func main() {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sigs
-		ctx.Log("event", fmt.Sprintf("Received shutdown request"))
+		ctx.Log("event", "Received shutdown request")
 		shutdown = true
 		err := killVMWatch(ctx, vmWatchCommand)
 		if err != nil {

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -27,3 +27,6 @@ RUN ln -s /var/lib/waagent/fake-waagent /sbin/fake-waagent && \
 COPY misc/HandlerManifest.json ./Extension/
 COPY misc/applicationhealth-shim ./Extension/bin/
 COPY bin/applicationhealth-extension ./Extension/bin/
+
+# Copy Helper functions and scripts
+COPY integration-test/test/test_helper.bash /var/lib/waagent


### PR DESCRIPTION
Changes by @dpoole73 
- Fix bug where we were not using the global `vmWatchCommand` variable so the SIGTERM handler was not killing anything
- set the `Pdealthsig` property on the command so the SIGTERM signal is sent to the sub process on parent process termination

This fixes both issues:

Before the fix if we killed app health process, vmwatch process was always leaked

After the fix:
`kill <pid>` -> log message "Received shutdown request" and kill vmwatch.
`kill -9 <pid>`-> no log message, vmwatch is killed

Changes by @klugorosado 
- Added Integration tests to kill AppHealth Gracefully with SIGTERM and SIGINT, and validated VMWatch Shutdown. 
- Added Integration tests to kill AppHealth Forcibly with SIGKILL, and validated VMWatch Shutdown. 
- Added the capability for dev containers to run Integration tests inside. 