### PR TITLE
fix(systemd-run): Switch to use systemd-run instead of direct process and cgroup manipulation

### DIFF
--- a/.gitattibutes
+++ b/.gitattibutes
@@ -3,3 +3,4 @@
 
 # make sure sh files are encoded with unix line endings
 *.sh text eol=lf
+*.bash text eol=lf

--- a/integration-test/test/parallel/7_vmwatch.bats
+++ b/integration-test/test/parallel/7_vmwatch.bats
@@ -351,7 +351,7 @@ teardown(){
     echo "$output"
     echo "$status_file"
     [[ "$output" == *'Setup VMWatch command: /var/lib/waagent/Extension/bin/VMWatch/vmwatch_linux_amd64'* ]]
-    [[ "$output" == *'Killing VMWatch process as cgroup assigment failed'* ]]
+    [[ "$output" == *'Killing VMWatch process as cgroup assignment failed'* ]]
     [[ "$output" == *'VMWatch reached max 3 retries, sleeping for 3 hours before trying again'* ]]
 
     verify_substatus_item "$status_file" AppHealthStatus success "Application found to be healthy"


### PR DESCRIPTION
**Background:**

Our tests have been running fine for a long time but suddenly started failing on specific os versions.  This was because the process (although initially associated with the correct cgroup that we created) gets moved back to the parent cgroup.  This results in the limits being removed.

I did some research and reached out to various people and found that this is something that has previously been seen.  

When a process is started with `systemd` you are not supposed to manage cgroups directly, `systemd` owns its own hierarchy and can manipulate things within it.  Documentation says that you should not modify the cgroups within that slice hierarchy directly but instead you should use `systemd-run` to launch processes.

The GuestAgent folks saw very similar behavior and switching to systemd-run resolved all their issues.

Changes:

Changed the code to run using `systemd-run` to launch the vmwatch process.  Using the `--scope` parameter results in the call to wait until the vmwatch process completes.

The process id returned from the call is the actual process id of vmwatch.

I have confirmed that killing vmwatch and killing app health extension still has the same behavior (the PDeathSig integration is working fine) and the aurora tests are working fine with these changes.

NOTE: Because in docker containers, systemd-run is not available, the code falls back to run the process directly and continues to use the old code path in that case.  This should also cover and linux distros which don't use systemd where direct cgroup assignment should work fine.