### PR TITLE
chore(testing): Changes to support running devcontainer based tests on Mac Silicon

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
     ],
     "containerEnv": {
         "RUNNING_IN_DEV_CONTAINER": "1",
-        "ALLOW_VMWATCH_CGROUP_ASSIGNMENT_FAILURE": "1"
+        "ALLOW_VMWATCH_CGROUP_ASSIGNMENT_FAILURE": "1",
+        "DOCKER_DEFAULT_PLATFORM": "linux/amd64"
     },
 
     "customizations": {

--- a/integration-test/env/wait-for-enable
+++ b/integration-test/env/wait-for-enable
@@ -21,7 +21,11 @@ done
 sleep 1
 bin="bin/applicationhealth-extension"
 while true; do
-    out="$(ps aux)"
+    # get running processes removing sh which is the entry command and has a bunch of commands in it
+    # this allows the statements below to work in native linux and on mac silicon where rosetta will
+    # show up so the format of ps aux changes a bit and more restrictive regexes don't find the data
+    # removing the entrypoint command allows the regexes to be less restrictive.
+    out="$(ps aux | grep -v sh)"
     if [ $waitonstatus == "y" ]; then
         log "waiting on successful status"
         if grep -q 'success' /var/lib/waagent/Extension/status/0.status; then
@@ -39,7 +43,7 @@ while true; do
         if [[ "$1" != "webserverexit" ]]; then
             log "'$bin' process exited"
             exit 0
-        elif [[ "$out" != **"0 webserver -args="** ]]; then
+        elif [[ "$out" != **"webserver -args="** ]]; then
             log "webserver exited"
             exit 0
         fi 

--- a/integration-test/test/sequential/1_basic.bats
+++ b/integration-test/test/sequential/1_basic.bats
@@ -10,7 +10,7 @@ setup() {
 }
 
 @test "meta: can build the test container image" {
-    run build_docker_image
+    run build_docker_image_nocache
     echo "$output"
     [ "$status" -eq 0 ]
 }

--- a/integration-test/test/test_helper.bash
+++ b/integration-test/test/test_helper.bash
@@ -7,6 +7,13 @@ TEST_CONTAINER=test
 certs_dir="$BATS_TEST_DIRNAME/certs"
 
 # This function builds a Docker image for testing purposes, if it already doesn't exist.
+build_docker_image_nocache() {
+    # Check if the image already exists
+    echo "Building test image $IMAGE..."
+    docker build --no-cache -q -f $DOCKERFILE -t $IMAGE . 1>&2
+}
+
+# This function builds a Docker image for testing purposes, if it already doesn't exist.
 build_docker_image() {
     # Check if the image already exists
     if [ -z "$(docker images -q $IMAGE)" ]; then
@@ -101,7 +108,7 @@ container_read_handler_log() {
 
 mk_certs() { # creates certs/{THUMBPRINT}.(crt|key) files under ./certs/ and prints THUMBPRINT
     set -eo pipefail
-    mkdir -p "$certs_dir" && cd "$certs_dir" && rm -f "$certs_dir/*"
+    mkdir -p "$certs_dir" && rm -f "$certs_dir/*" && cd "$certs_dir"
     openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 365 -nodes -batch &>/dev/null
     thumbprint=$(openssl x509 -in cert.pem -fingerprint -noout| sed 's/.*=//g' | sed 's/://g')
     mv cert.pem $thumbprint.crt && \


### PR DESCRIPTION
I have been unable to run the integration tests locally since upgrading my laptop.  I worked with kevin to figure out the issues and the tests are working now.

1. changing to build the test container using no-cache mode since if you have an old bad version it would not get rebuilt.
1. changing the devconatiner config to force running amd64 rather than arm64
1. tweaking the scripts to handle the slightly different process names and ps output when running in this way.

now, the tests pass on mac