### PR TITLE
Improve logging to kusto for better debugging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22
 
 require (
 	github.com/Azure/azure-docker-extension v0.0.0-20160802215703-0dd2f199467d
-	github.com/Azure/azure-extension-platform v0.0.0-20240327184133-73b5b3b55955
+	github.com/Azure/azure-extension-platform v0.0.0-20240521173920-6b2acfda81e9
 	github.com/containerd/cgroups/v3 v3.0.2
 	github.com/opencontainers/runtime-spec v1.0.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/Azure/azure-docker-extension v0.0.0-20160802215703-0dd2f199467d h1:IZq7wAvhHb/IObHOh8RHClV2zv4dHh5MrHdRWTTIwe0=
 github.com/Azure/azure-docker-extension v0.0.0-20160802215703-0dd2f199467d/go.mod h1:tVA4DYQYxotjw+EkJhfywtM99w7nAOatBvgNAkpsBvk=
-github.com/Azure/azure-extension-platform v0.0.0-20240327184133-73b5b3b55955 h1:klRZMtNE2mFdG8mO3+Ep7Armk1oewdw/7Z4nANDiGgk=
-github.com/Azure/azure-extension-platform v0.0.0-20240327184133-73b5b3b55955/go.mod h1:nEQQIC3RKmMnpdc+RakYHIdu556jdcHv67ML8PdsQeQ=
+github.com/Azure/azure-extension-platform v0.0.0-20240521173920-6b2acfda81e9 h1:/DP5C4Fx89JD/Te5ZDIG5hNNqUS0Jkaytqk+FP0owpM=
+github.com/Azure/azure-extension-platform v0.0.0-20240521173920-6b2acfda81e9/go.mod h1:nEQQIC3RKmMnpdc+RakYHIdu556jdcHv67ML8PdsQeQ=
 github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
 github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
 github.com/containerd/cgroups/v3 v3.0.2 h1:f5WFqIVSgo5IZmtTT3qVBo6TzI1ON6sycSBKkymb9L0=

--- a/internal/handlerenv/handlerenv.go
+++ b/internal/handlerenv/handlerenv.go
@@ -12,7 +12,7 @@ type HandlerEnvironment struct {
 }
 
 func (he *HandlerEnvironment) String() string {
-	env, _ := json.MarshalIndent(he, "", "    ")
+	env, _ := json.MarshalIndent(he, "", "\t")
 	return string(env)
 }
 

--- a/main/handlersettings.go
+++ b/main/handlersettings.go
@@ -28,7 +28,7 @@ type handlerSettings struct {
 }
 
 func (s handlerSettings) String() string {
-	settings, _ := json.MarshalIndent(s, "", "    ")
+	settings, _ := json.MarshalIndent(s, "", "\t")
 	return string(settings)
 }
 
@@ -113,7 +113,7 @@ type vmWatchSettings struct {
 }
 
 func (v *vmWatchSettings) String() string {
-	setting, _ := json.MarshalIndent(v, "", "    ")
+	setting, _ := json.MarshalIndent(v, "", "\t")
 	return string(setting)
 }
 

--- a/main/main.go
+++ b/main/main.go
@@ -74,8 +74,7 @@ func main() {
 	if cmd.pre != nil {
 		logger.Log("event", "pre-check")
 		if err := cmd.pre(logger, seqNum); err != nil {
-			logger.Log("event", "pre-check failed", "error", err)
-			sendTelemetry(logger, telemetry.EventLevelError, telemetry.MainTask, fmt.Sprintf("pre-check failed with error %s", err))
+			sendTelemetry(logger, telemetry.EventLevelError, telemetry.MainTask, "pre-check failed", "error", err.Error())
 			os.Exit(cmd.failExitCode)
 		}
 	}

--- a/main/reportstatus.go
+++ b/main/reportstatus.go
@@ -21,7 +21,7 @@ func reportStatus(lg log.Logger, hEnv *handlerenv.HandlerEnvironment, seqNum int
 	}
 	s := NewStatus(t, c.name, statusMsg(c, t, msg))
 	if err := s.Save(hEnv.StatusFolder, seqNum); err != nil {
-		sendTelemetry(lg, telemetry.EventLevelError, telemetry.ReportStatusTask, "failed to save handler status", "error", err.Error())
+		sendTelemetry(lg, telemetry.EventLevelError, telemetry.ReportStatusTask, fmt.Sprintf("failed to save handler status: %s", s), "error", err.Error())
 		return errors.Wrap(err, "failed to save handler status")
 	}
 	sendTelemetry(lg, telemetry.EventLevelInfo, telemetry.ReportStatusTask, fmt.Sprintf("saved handler status: %s", s))

--- a/main/reportstatus.go
+++ b/main/reportstatus.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/Azure/applicationhealth-extension-linux/internal/handlerenv"
 	"github.com/Azure/applicationhealth-extension-linux/internal/telemetry"
 	"github.com/go-kit/log"
@@ -19,9 +21,11 @@ func reportStatus(lg log.Logger, hEnv *handlerenv.HandlerEnvironment, seqNum int
 	}
 	s := NewStatus(t, c.name, statusMsg(c, t, msg))
 	if err := s.Save(hEnv.StatusFolder, seqNum); err != nil {
-		lg.Log("event", "failed to save handler status", "error", err)
+		sendTelemetry(lg, telemetry.EventLevelError, telemetry.ReportStatusTask, "failed to save handler status", "error", err.Error())
 		return errors.Wrap(err, "failed to save handler status")
 	}
+	sendTelemetry(lg, telemetry.EventLevelInfo, telemetry.ReportStatusTask, fmt.Sprintf("saved handler status: %s", s))
+
 	return nil
 }
 
@@ -31,7 +35,7 @@ func reportStatusWithSubstatuses(lg log.Logger, hEnv *handlerenv.HandlerEnvironm
 		s.AddSubstatusItem(substatus)
 	}
 	if err := s.Save(hEnv.StatusFolder, seqNum); err != nil {
-		sendTelemetry(lg, telemetry.EventLevelInfo, telemetry.ReportStatusTask, "failed to save handler status", "error", err.Error())
+		sendTelemetry(lg, telemetry.EventLevelError, telemetry.ReportStatusTask, fmt.Sprintf("failed to save handler status: %s", s), "error", err.Error())
 		return errors.Wrap(err, "failed to save handler status")
 	}
 	return nil

--- a/main/status.go
+++ b/main/status.go
@@ -124,3 +124,8 @@ func (r StatusReport) Save(statusFolder string, seqNum int) error {
 	}
 	return nil
 }
+
+func (r StatusReport) String() string {
+	report, _ := json.MarshalIndent(r, "", "\t")
+	return string(report)
+}

--- a/vendor/github.com/Azure/azure-extension-platform/pkg/extensionevents/extension_events.go
+++ b/vendor/github.com/Azure/azure-extension-platform/pkg/extensionevents/extension_events.go
@@ -49,7 +49,7 @@ func (eem *ExtensionEventManager) logEvent(taskName string, eventLevel string, m
 	}
 
 	extensionVersion := os.Getenv("AZURE_GUEST_AGENT_EXTENSION_VERSION")
-	timestamp := time.Now().UTC().Format(time.RFC3339)
+	timestamp := time.Now().UTC().Format(time.RFC3339Nano)
 	pid := fmt.Sprintf("%v", os.Getpid())
 	tid := getThreadID()
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,7 +1,7 @@
 # github.com/Azure/azure-docker-extension v0.0.0-20160802215703-0dd2f199467d
 ## explicit
 github.com/Azure/azure-docker-extension/pkg/vmextension
-# github.com/Azure/azure-extension-platform v0.0.0-20240327184133-73b5b3b55955
+# github.com/Azure/azure-extension-platform v0.0.0-20240521173920-6b2acfda81e9
 ## explicit; go 1.21
 github.com/Azure/azure-extension-platform/pkg/extensionerrors
 github.com/Azure/azure-extension-platform/pkg/extensionevents


### PR DESCRIPTION
Some info is missing in the kusto logs that are present in the local logs that makes it difficult to debug.

- Log specific command being executed at startup (install/enable/update/etc)
- Include extension sequence number and pid at startup for debugging from GuestAgent logs when extension logs are missing or seqNum.status file is missing
- Log overall status file so we have better debugging when VMExtensionProvisioning fails. This status is only sent when extension transitions between Transitioning -> Success/Error or whenever extension starts up.
- Update azure-extension-platform package to pull in change to increase precision of event timestamp to include milliseconds/nanoseconds, Previously it was RFC3339, which is in format yyyy-mm-ddThh:mm:ssZ, which causes issue in sorting timestamps. https://github.com/Azure/azure-extension-platform/pull/34