### PR TITLE
fix(shim): Fix timing issue in shim script

### DIFF
--- a/misc/applicationhealth-shim
+++ b/misc/applicationhealth-shim
@@ -59,7 +59,7 @@ kill_existing_apphealth_processes() {
     out="$(ps aux)"
     if [[ "$out" == **"$HANDLER_BIN enable"** ]]; then
         echo "Terminating existing $HANDLER_BIN process"
-        pkill -f $HANDLER_BIN >&2
+        pkill -f $HANDLER_BIN >&2 || true
         echo "Tried terminating existing $HANDLER_BIN process"
         for i in {1..33};
         do
@@ -83,7 +83,7 @@ kill_existing_vmwatch_processes() {
     out="$(ps aux)"
     if [[ "$out" == **"$VMWATCH_BIN"** ]]; then
         echo "Terminating existing $VMWATCH_BIN process"
-        pkill -f $VMWATCH_BIN >&2
+        pkill -f $VMWATCH_BIN >&2 || true
         echo "Tried terminating existing $VMWATCH_BIN process"
         for i in {1..33};
         do


### PR DESCRIPTION
We discovered that there is a timing issue in the script which can cause it to fail, this resulting in settings update timeouts.

Explanation:

1. `kill_existing_apphealth_processes` checks for app health running and see it is running
1. it kills the process using `pkill -f`, this succeeds.
1. killing app health causes vmwatch to be sent a kill signal
1. `kill_existing_vmwatch_processes` checks for vmwatch running and sees it is there because it hasn't quite reacted to the kill signal yet
1. tries to kill it using `pkill -f` but it has already gone so it fails and because the script is running with `set -e` it fails immediately

the fix:

add `|| true` to the command so that failures are ignored.  If it actually failed to kill the process for some reason the script will still poll and fall back to `pkill -9` so there is no change in behavior in the case of a real issue killing the process, just fixes a timing issue