### PR TITLE
chore(logging): Logging the error code if kill fails

### DIFF
--- a/misc/applicationhealth-shim
+++ b/misc/applicationhealth-shim
@@ -59,7 +59,7 @@ kill_existing_apphealth_processes() {
     out="$(ps aux)"
     if [[ "$out" == **"$HANDLER_BIN enable"** ]]; then
         echo "Terminating existing $HANDLER_BIN process"
-        pkill -f $HANDLER_BIN >&2 || true
+        pkill -f $HANDLER_BIN >&2 || echo "pkill -f $HANDLER_BIN failed with error $?"
         echo "Tried terminating existing $HANDLER_BIN process"
         for i in {1..33};
         do
@@ -83,7 +83,7 @@ kill_existing_vmwatch_processes() {
     out="$(ps aux)"
     if [[ "$out" == **"$VMWATCH_BIN"** ]]; then
         echo "Terminating existing $VMWATCH_BIN process"
-        pkill -f $VMWATCH_BIN >&2 || true
+        pkill -f $VMWATCH_BIN >&2 || echo "pkill -f $VMWATCH_BIN failed with error $?"
         echo "Tried terminating existing $VMWATCH_BIN process"
         for i in {1..33};
         do
@@ -110,6 +110,8 @@ if [ "$#" -ne 1 ]; then
 fi
 
 kill_existing_apphealth_processes
+# give vmwatch sub process time to die after on killing app health process
+sleep 1
 kill_existing_vmwatch_processes
 
 # Redirect logs of the handler process


### PR DESCRIPTION
We investigated this at length and cannot figure out what could possibly be happening based on the logs.  Logging the fact that kill failed should help us at least narrow it down further.

Also adding a sleep between killing app health and vmwatch to reduce the chance of any races (vmwatch should die naturally when app health is killed but it may not happen immediately so giving it a second to respond should reduce the times it needs to be killed independently.