### PR TITLE
Upgrade from Ubuntu-20.04 to Ubuntu-22.04

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04]
+        os: [ubuntu-latest, ubuntu-24.04]
     
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04]
+        os: [ubuntu-latest, ubuntu-22.04]
     
     runs-on: ${{ matrix.os }}
 

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 RUN apt-get -qqy update && \
 	apt-get -qqy install jq openssl ca-certificates && \

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 RUN apt-get -qqy update && \
 	apt-get -qqy install jq openssl ca-certificates && \


### PR DESCRIPTION
The Ubuntu-20.04 image has been recently deprecated: [The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-15](https://github.com/actions/runner-images/issues/11101) so this PR replaces it with Ubuntu-22.04