### PR TITLE
Suppress CodeQL warning for TLS certificate validation

### DIFF
--- a/main/health.go
+++ b/main/health.go
@@ -161,7 +161,7 @@ func NewHttpHealthProbe(protocol string, requestPath string, port int) *HttpHeal
 			// from tls1.0 to tls1.2 and we want to support customers who are using tls1.0.
 			// tls MaxVersion is set to tls1.3 by default.
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: true, // CodeQL [SM03511] Ignore TLS certificate validation, since the endpoint will be on localhost.
 				MinVersion:         tls.VersionTLS10,
 			},
 		}


### PR DESCRIPTION
This change solves an S360 item for CodeQL. The security standards enforce all the SSL/TLS certificates used in code to be validated.

We add a `// CodeQL [IssueID]` comment to suppress the warning for this use case, since the HTTP target will always be `localhost` for health probes.