### PR TITLE
Redact SAS tokens/secrets from VMWatch logs and bump AppHealth to 2.0.28

### DIFF
--- a/main/cmds.go
+++ b/main/cmds.go
@@ -264,7 +264,7 @@ func enable(lg *slog.Logger, h *handlerenv.HandlerEnvironment, seqNum uint) (str
 		}
 	}
 
-	telemetry.SendEvent(telemetry.InfoEvent, telemetry.AppHealthTask, fmt.Sprintf("VMWatch settings: %s", vmWatchSettings))
+	telemetry.SendEvent(telemetry.InfoEvent, telemetry.AppHealthTask, fmt.Sprintf("VMWatch settings: %s", redact.JSON(vmWatchSettings.String())))
 	if vmWatchSettings == nil || vmWatchSettings.Enabled == false {
 		telemetry.SendEvent(telemetry.InfoEvent, telemetry.StartVMWatchTask, "VMWatch is disabled, not starting process.")
 	} else {

--- a/main/cmds.go
+++ b/main/cmds.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Azure/applicationhealth-extension-linux/internal/handlerenv"
 	"github.com/Azure/applicationhealth-extension-linux/internal/telemetry"
+	"github.com/Azure/applicationhealth-extension-linux/pkg/redact"
 	"github.com/pkg/errors"
 )
 
@@ -229,7 +230,7 @@ func enable(lg *slog.Logger, h *handlerenv.HandlerEnvironment, seqNum uint) (str
 	}
 
 	telemetry.SendEvent(telemetry.InfoEvent, telemetry.AppHealthTask, "Successfully parsed and validated settings")
-	telemetry.SendEvent(telemetry.VerboseEvent, telemetry.AppHealthTask, fmt.Sprintf("HandlerSettings = %s", cfg))
+	telemetry.SendEvent(telemetry.VerboseEvent, telemetry.AppHealthTask, fmt.Sprintf("HandlerSettings = %s", redact.JSON(cfg.String())))
 
 	probe := NewHealthProbe(lg, &cfg)
 	var (

--- a/main/vmWatch.go
+++ b/main/vmWatch.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Azure/applicationhealth-extension-linux/internal/handlerenv"
 	"github.com/Azure/applicationhealth-extension-linux/internal/telemetry"
+	"github.com/Azure/applicationhealth-extension-linux/pkg/redact"
 	"github.com/containerd/cgroups/v3"
 	"github.com/containerd/cgroups/v3/cgroup1"
 	"github.com/containerd/cgroups/v3/cgroup2"
@@ -212,9 +213,11 @@ func executeVMWatchHelper(lg *slog.Logger, attempt int, vmWatchSettings *vmWatch
 		return err
 	}
 
+	// Redact potential secrets (e.g. SAS tokens in the global config URL or
+	// parameter-override env vars) before writing the command to telemetry.
 	telemetry.SendEvent(telemetry.InfoEvent, telemetry.SetupVMWatchTask,
 		fmt.Sprintf("Attempt %d: Setup VMWatch command: %s\nArgs: %v\nDir: %s\nEnv: %v\n",
-			attempt, vmWatchCommand.Path, vmWatchCommand.Args, vmWatchCommand.Dir, vmWatchCommand.Env),
+			attempt, vmWatchCommand.Path, redact.Slice(vmWatchCommand.Args), vmWatchCommand.Dir, redact.Slice(vmWatchCommand.Env)),
 	)
 	// TODO: Combined output may get excessively long, especially since VMWatch is a long running process
 	// We should trim the output or only get from Stderr
@@ -225,7 +228,7 @@ func executeVMWatchHelper(lg *slog.Logger, attempt int, vmWatchSettings *vmWatch
 
 	// Start command
 	if err := vmWatchCommand.Start(); err != nil {
-		err = fmt.Errorf("[%v][PID -1] Attempt %d: VMWatch failed to start. Error: %w\nOutput: %s", time.Now().UTC().Format(time.RFC3339), attempt, err, combinedOutput.String())
+		err = fmt.Errorf("[%v][PID -1] Attempt %d: VMWatch failed to start. Error: %w\nOutput: %s", time.Now().UTC().Format(time.RFC3339), attempt, err, redact.Text(combinedOutput.String()))
 		telemetry.SendEvent(telemetry.ErrorEvent, telemetry.StartVMWatchTask, err.Error(), "error", err)
 		return err
 	}
@@ -238,7 +241,7 @@ func executeVMWatchHelper(lg *slog.Logger, attempt int, vmWatchSettings *vmWatch
 		err = applyResourceGovernance(lg, vmWatchSettings, vmWatchCommand)
 		if err != nil {
 			// if this has failed we have already killed the process as we failed to assign to cgroup so log the appropriate error
-			err = fmt.Errorf("[%v][PID %d] Attempt %d: VMWatch process exited. Error: %w\nOutput: %s", time.Now().UTC().Format(time.RFC3339), pid, attempt, err, combinedOutput.String())
+			err = fmt.Errorf("[%v][PID %d] Attempt %d: VMWatch process exited. Error: %w\nOutput: %s", time.Now().UTC().Format(time.RFC3339), pid, attempt, err, redact.Text(combinedOutput.String()))
 			telemetry.SendEvent(telemetry.ErrorEvent, telemetry.StopVMWatchTask, err.Error(), "error", err)
 			return err
 		}
@@ -263,7 +266,7 @@ func executeVMWatchHelper(lg *slog.Logger, attempt int, vmWatchSettings *vmWatch
 		monitorHeartBeat(lg, GetVMWatchHeartbeatFilePath(hEnv), processDone, vmWatchCommand, time.Now())
 	}()
 	wg.Wait()
-	err = fmt.Errorf("[%v][PID %d] Attempt %d: VMWatch process exited. Error: %w\nOutput: %s", time.Now().UTC().Format(time.RFC3339), pid, attempt, err, combinedOutput.String())
+	err = fmt.Errorf("[%v][PID %d] Attempt %d: VMWatch process exited. Error: %w\nOutput: %s", time.Now().UTC().Format(time.RFC3339), pid, attempt, err, redact.Text(combinedOutput.String()))
 	telemetry.SendEvent(telemetry.ErrorEvent, telemetry.StopVMWatchTask, err.Error(), "error", err)
 	return err
 }
@@ -639,7 +642,6 @@ func GetVMWatchEnvironmentVariables(parameterOverrides map[string]interface{}, h
 	sort.Strings(keys)
 	for _, k := range keys {
 		arr = append(arr, fmt.Sprintf("%s=%s", k, parameterOverrides[k]))
-		fmt.Println(k, parameterOverrides[k])
 	}
 
 	arr = append(arr, fmt.Sprintf("SIGNAL_FOLDER=%s", hEnv.EventsFolder))

--- a/misc/manifest.xml
+++ b/misc/manifest.xml
@@ -2,7 +2,7 @@
 <ExtensionImage xmlns="http://schemas.microsoft.com/windowsazure">
   <ProviderNameSpace>Microsoft.ManagedServices</ProviderNameSpace>
   <Type>ApplicationHealthLinux</Type>
-  <Version>2.0.27</Version>
+  <Version>2.0.28</Version>
   <Label>Microsoft Azure Application Health Extension for Linux Virtual Machines</Label>
   <HostingResources>VmRole</HostingResources>
   <MediaLink></MediaLink>

--- a/pkg/redact/redact.go
+++ b/pkg/redact/redact.go
@@ -1,0 +1,70 @@
+// Package redact provides helpers for scrubbing sensitive data (SAS tokens,
+// account keys, passwords, etc.) from strings before they are written to logs
+// or telemetry.
+package redact
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Placeholder is substituted for secret values that have been redacted.
+const Placeholder = "<redacted>"
+
+// sensitiveKeywords is the alternation of substrings that mark a key/name as
+// likely to carry a secret (e.g. SAS tokens, account keys, passwords). It is
+// shared by the key-name and JSON-field matchers so the rules stay in sync.
+const sensitiveKeywords = `sas|token|secret|password|passwd|pwd|credential|connection[_-]?string|account[_-]?key|api[_-]?key|access[_-]?key`
+
+// sensitiveKeyPattern matches environment variable / attribute names that are
+// likely to carry secrets (e.g. SAS tokens, account keys, passwords).
+var sensitiveKeyPattern = regexp.MustCompile(`(?i)(` + sensitiveKeywords + `)`)
+
+// jsonSensitiveFieldPattern matches a JSON string field whose key name looks
+// sensitive, capturing the key (and separator) so the value can be replaced.
+// Only string values are matched; numbers/booleans/objects are left untouched.
+var jsonSensitiveFieldPattern = regexp.MustCompile(`(?i)("[^"]*(?:` + sensitiveKeywords + `)[^"]*"\s*:\s*)"(?:[^"\\]|\\.)*"`)
+
+// urlQueryPattern matches the query-string portion of an http(s) URL, where SAS
+// tokens and similar credentials are typically passed. The character classes stop
+// at whitespace and quote/bracket delimiters so that URLs embedded in JSON or
+// other structured text keep their surrounding syntax intact.
+var urlQueryPattern = regexp.MustCompile(`(https?://[^\s?"'<>]+)\?[^\s"'<>]*`)
+
+// Value scrubs a single string that may contain secrets before it is written to
+// logs or telemetry. It redacts the value of a KEY=VALUE pair whose key looks
+// sensitive, and strips query strings (which may hold SAS tokens) from any URLs.
+func Value(s string) string {
+	if idx := strings.Index(s, "="); idx > 0 && sensitiveKeyPattern.MatchString(s[:idx]) {
+		return s[:idx+1] + Placeholder
+	}
+	return urlQueryPattern.ReplaceAllString(s, "$1?"+Placeholder)
+}
+
+// Slice returns a copy of values with sensitive data redacted so that command
+// args/env can be safely logged. The input slice is not modified.
+func Slice(values []string) []string {
+	redacted := make([]string, len(values))
+	for i, v := range values {
+		redacted[i] = Value(v)
+	}
+	return redacted
+}
+
+// Text scrubs secrets from free-form, possibly multi-line text (such as captured
+// process output or serialized settings) before it is logged. It strips query
+// strings (which may contain SAS tokens) from every URL it contains. Unlike
+// Value, it does not apply KEY=VALUE redaction, so it is safe to run over
+// arbitrary text without corrupting unrelated content.
+func Text(s string) string {
+	return urlQueryPattern.ReplaceAllString(s, "$1?"+Placeholder)
+}
+
+// JSON scrubs secrets from a JSON document (such as serialized settings) before
+// it is logged. It replaces the string value of any field whose key name looks
+// sensitive with the placeholder, and strips query strings (SAS tokens) from any
+// URLs. The result remains valid JSON.
+func JSON(s string) string {
+	s = jsonSensitiveFieldPattern.ReplaceAllString(s, `${1}"`+Placeholder+`"`)
+	return urlQueryPattern.ReplaceAllString(s, "$1?"+Placeholder)
+}

--- a/pkg/redact/redact_test.go
+++ b/pkg/redact/redact_test.go
@@ -1,0 +1,184 @@
+package redact
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValue_RedactsSensitiveKeyValuePairs(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"sas token env", "AZ_STORAGE_SAS_TOKEN_BASE64=abc123", "AZ_STORAGE_SAS_TOKEN_BASE64=" + Placeholder},
+		{"password", "DB_PASSWORD=hunter2", "DB_PASSWORD=" + Placeholder},
+		{"secret", "MY_SECRET=shh", "MY_SECRET=" + Placeholder},
+		{"account key with underscore", "STORAGE_ACCOUNT_KEY=xyz", "STORAGE_ACCOUNT_KEY=" + Placeholder},
+		{"api-key with dash", "API-KEY=xyz", "API-KEY=" + Placeholder},
+		{"access key", "ACCESS_KEY=xyz", "ACCESS_KEY=" + Placeholder},
+		{"connection string", "CONNECTION_STRING=Server=x;Pwd=y", "CONNECTION_STRING=" + Placeholder},
+		{"token case insensitive", "authToken=abc", "authToken=" + Placeholder},
+		{"empty value still redacted", "PASSWORD=", "PASSWORD=" + Placeholder},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, Value(tc.input))
+		})
+	}
+}
+
+func TestValue_DoesNotRedactBenignKeyValuePairs(t *testing.T) {
+	cases := []string{
+		"SIGNAL_FOLDER=/var/log/azure/events",
+		"VERBOSE_LOG_FILE_FULL_PATH=/var/log/azure/vmwatch.log",
+		"REGION=eastus",
+		"COUNT=5",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			require.Equal(t, in, Value(in))
+		})
+	}
+}
+
+func TestValue_StripsUrlQueryString(t *testing.T) {
+	in := "https://acct.blob.core.windows.net/c/cfg.json?sv=2021&sig=SECRETSIG&se=2030"
+	want := "https://acct.blob.core.windows.net/c/cfg.json?" + Placeholder
+	require.Equal(t, want, Value(in))
+}
+
+func TestValue_StripsUrlQueryInBenignKeyValue(t *testing.T) {
+	// Key is not sensitive, but the URL value carries a SAS token in the query.
+	in := "GLOBAL_CONFIG_URL=https://acct.blob.core.windows.net/c/cfg.json?sig=SECRET"
+	want := "GLOBAL_CONFIG_URL=https://acct.blob.core.windows.net/c/cfg.json?" + Placeholder
+	require.Equal(t, want, Value(in))
+}
+
+func TestValue_UrlWithoutQueryUnchanged(t *testing.T) {
+	in := "https://acct.blob.core.windows.net/c/cfg.json"
+	require.Equal(t, in, Value(in))
+}
+
+func TestValue_PlainStringUnchanged(t *testing.T) {
+	in := "--global-config-url"
+	require.Equal(t, in, Value(in))
+}
+
+func TestValue_LeadingEqualsNotTreatedAsKey(t *testing.T) {
+	// idx must be > 0; a leading '=' has no key name to inspect.
+	in := "=value"
+	require.Equal(t, in, Value(in))
+}
+
+func TestSlice_RedactsEachElementAndCopies(t *testing.T) {
+	in := []string{
+		"--global-config-url",
+		"https://acct.blob.core.windows.net/c/cfg.json?sig=SECRET",
+		"--setenv",
+		"AZ_STORAGE_SAS_TOKEN_BASE64=abc123",
+		"SIGNAL_FOLDER=/var/log/azure/events",
+	}
+	want := []string{
+		"--global-config-url",
+		"https://acct.blob.core.windows.net/c/cfg.json?" + Placeholder,
+		"--setenv",
+		"AZ_STORAGE_SAS_TOKEN_BASE64=" + Placeholder,
+		"SIGNAL_FOLDER=/var/log/azure/events",
+	}
+	got := Slice(in)
+	require.Equal(t, want, got)
+
+	// The original slice must be left untouched.
+	require.Equal(t, "https://acct.blob.core.windows.net/c/cfg.json?sig=SECRET", in[1])
+	require.Equal(t, "AZ_STORAGE_SAS_TOKEN_BASE64=abc123", in[3])
+}
+
+func TestSlice_EmptyAndNil(t *testing.T) {
+	require.Equal(t, []string{}, Slice(nil))
+	require.Equal(t, []string{}, Slice([]string{}))
+}
+
+func TestText_StripsSasFromJsonKeepingQuotesIntact(t *testing.T) {
+	in := "\t\"globalConfigUrl\": \"https://acct.blob.core.windows.net/c/cfg.json?sv=2025-11-05&sig=Te8r%2FkH2%3D\"\n"
+	want := "\t\"globalConfigUrl\": \"https://acct.blob.core.windows.net/c/cfg.json?" + Placeholder + "\"\n"
+	require.Equal(t, want, Text(in))
+}
+
+func TestText_StripsMultipleUrlsInMultilineText(t *testing.T) {
+	in := "line1 https://a.example.com/x?sig=AAA more\nline2 http://b.example.com/y?token=BBB end"
+	want := "line1 https://a.example.com/x?" + Placeholder + " more\nline2 http://b.example.com/y?" + Placeholder + " end"
+	require.Equal(t, want, Text(in))
+}
+
+func TestText_DoesNotApplyKeyValueRedaction(t *testing.T) {
+	// Unlike Value, Text must not redact KEY=VALUE pairs (no first-'=' heuristic),
+	// so unrelated content is preserved verbatim.
+	in := "AZ_STORAGE_SAS_TOKEN_BASE64=abc123 no-url-here"
+	require.Equal(t, in, Text(in))
+}
+
+func TestText_NoUrlUnchanged(t *testing.T) {
+	in := "just some log output with an = sign and no urls"
+	require.Equal(t, in, Text(in))
+}
+
+func TestValue_StripsUrlQueryInJsonKeepsClosingQuote(t *testing.T) {
+	in := "\"https://acct.blob.core.windows.net/c/cfg.json?sig=SECRET\""
+	want := "\"https://acct.blob.core.windows.net/c/cfg.json?" + Placeholder + "\""
+	require.Equal(t, want, Value(in))
+}
+
+func TestJSON_RedactsSensitiveParameterOverrides(t *testing.T) {
+	in := "{\n\t\"parameterOverrides\": {\n\t\t\"AZ_STORAGE_SAS_TOKEN_BASE64\": \"abc123\",\n\t\t\"EVENT_HUB_OUTPUT_NAME\": \"evhname\"\n\t}\n}"
+	got := JSON(in)
+	require.Contains(t, got, "\"AZ_STORAGE_SAS_TOKEN_BASE64\": \""+Placeholder+"\"")
+	require.Contains(t, got, "\"EVENT_HUB_OUTPUT_NAME\": \"evhname\"")
+	require.NotContains(t, got, "abc123")
+}
+
+func TestJSON_StripsSasFromGlobalConfigUrlAndStaysValid(t *testing.T) {
+	type settings struct {
+		GlobalConfigUrl string `json:"globalConfigUrl"`
+		Password        string `json:"password"`
+		AccountKey      string `json:"storageAccountKey"`
+		Region          string `json:"region"`
+		Count           int    `json:"count"`
+	}
+	raw, err := json.MarshalIndent(settings{
+		GlobalConfigUrl: "https://acct.blob.core.windows.net/c/cfg.json?sv=2025-11-05&sig=Te8r%2FkH2%3D",
+		Password:        "hunter2",
+		AccountKey:      "AAAABBBBCCCC==",
+		Region:          "eastus",
+		Count:           5,
+	}, "", "\t")
+	require.NoError(t, err)
+
+	got := JSON(string(raw))
+
+	// Output must remain valid JSON.
+	var out map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(got), &out))
+
+	require.Equal(t, "https://acct.blob.core.windows.net/c/cfg.json?"+Placeholder, out["globalConfigUrl"])
+	require.Equal(t, Placeholder, out["password"])
+	require.Equal(t, Placeholder, out["storageAccountKey"])
+	require.Equal(t, "eastus", out["region"])
+	require.Equal(t, float64(5), out["count"])
+	require.NotContains(t, got, "hunter2")
+	require.NotContains(t, got, "AAAABBBBCCCC")
+	require.NotContains(t, got, "sig=")
+}
+
+func TestJSON_LeavesNonStringSensitiveValuesUntouched(t *testing.T) {
+	// Sensitive-looking keys with non-string values must not be corrupted.
+	in := "{\n\t\"useToken\": true,\n\t\"tokenCount\": 3\n}"
+	require.Equal(t, in, JSON(in))
+}
+
+func TestJSON_NoSensitiveFieldsUnchanged(t *testing.T) {
+	in := "{\n\t\"region\": \"eastus\",\n\t\"port\": 8080\n}"
+	require.Equal(t, in, JSON(in))
+}


### PR DESCRIPTION
## Summary
Sensitive data (SAS tokens, account keys, passwords) could leak into extension logs/telemetry. This adds a shared `pkg/redact` package and applies it at every spot that logs the VMWatch command or settings, and bumps the AppHealth Linux extension version.

## Leak vectors fixed
- **Command args/env telemetry** (main/vmWatch.go) - the `--global-config-url` SAS token and secret `--setenv`/env parameter overrides were logged verbatim. Now wrapped with `redact.Slice`.
- **Captured VMWatch process output** (3 error events) - could echo the SAS URL (VMWatch runs with `--debug`). Now wrapped with `redact.Text`.
- **HandlerSettings dump** (main/cmds.go, Verbose) - full settings JSON incl. `globalConfigUrl` (SAS) and `parameterOverrides` secrets. Now wrapped with `redact.JSON`.
- **VMWatch settings event** (main/cmds.go, Info) - `vmWatchSettings.String()` JSON incl. `globalConfigUrl`/`parameterOverrides`. Now wrapped with `redact.JSON` (review feedback).
- Removed a leftover `fmt.Println` that printed parameter-override values to stdout.

## Version bump
- `misc/manifest.xml`: AppHealth Linux `2.0.27` -> `2.0.28`.

## pkg/redact API
- `Value(s)` / `Slice(vals)` - redact `KEY=VALUE` secrets and strip URL query strings (command args/env).
- `Text(s)` - strip URL query strings from free-form/multi-line text (process output).
- `JSON(s)` - redact sensitive string fields by key name + strip URL queries, keeping output valid JSON (settings dumps).

## Result
Example: `--global-config-url https://...cfg.json?sv=...&sig=SECRET` -> `https://...cfg.json?<redacted>`; `AZ_STORAGE_SAS_TOKEN_BASE64=...` -> `AZ_STORAGE_SAS_TOKEN_BASE64=<redacted>`. Non-secret values (client IDs, paths, region, cohort IDs) are preserved for debuggability.

## Tests
Unit tests in `pkg/redact/redact_test.go` cover key-name redaction, URL SAS stripping (incl. inside JSON with quotes preserved and re-parse validation), non-string/benign fields untouched, and slice copy semantics. `go vet ./main ./pkg/redact` clean.